### PR TITLE
PCA on typed sites only, allow for redoing pca in scoring

### DIFF
--- a/ImputationPipeline/EndToEndPipeline.wdl
+++ b/ImputationPipeline/EndToEndPipeline.wdl
@@ -36,8 +36,6 @@ workflow EndToEndPipeline {
 	  File? population_meansd = "gs://fc-6413177b-e99c-4476-b085-3da80d320081/RiskScoreAdjustmentFiles/WallacesPCASites/sorted_thousand_genomes_wallace_sites.pc.meansd"
 	  File? population_pcs = "gs://fc-6413177b-e99c-4476-b085-3da80d320081/RiskScoreAdjustmentFiles/WallacesPCASites/sorted_thousand_genomes_wallace_sites.pc"
 	  File? pruning_sites_for_pca = "gs://fc-6413177b-e99c-4476-b085-3da80d320081/RiskScoreAdjustmentFiles/WallacesPCASites/wallace_pruning_sites_sorted_ids.txt"
-	  File? population_scoring_sites
-	  
 
 	  ## The following are inputs for scoring and performing the adjustment
 
@@ -85,8 +83,7 @@ workflow EndToEndPipeline {
 	    population_loadings = select_first([PopulationPCASteps.population_loadings, population_loadings]), # either use your newely generated PC files or the input loadings/meansd/pcs/pruning sites
 	    population_meansd = select_first([PopulationPCASteps.population_meansd, population_meansd]), 
 	    population_pcs = select_first([PopulationPCASteps.population_pcs, population_pcs]),
-	    pruning_sites_for_pca = select_first([PopulationPCASteps.pruning_sites_for_pca, pruning_sites_for_pca]),
-	    population_scoring_sites = select_first([PopulationPCASteps.population_sites_for_scoring, population_scoring_sites])
+	    pruning_sites_for_pca = select_first([PopulationPCASteps.pruning_sites_for_pca, pruning_sites_for_pca])
 	}
 
 	output {

--- a/ImputationPipeline/EndToEndPipeline.wdl
+++ b/ImputationPipeline/EndToEndPipeline.wdl
@@ -36,6 +36,7 @@ workflow EndToEndPipeline {
 	  File? population_meansd = "gs://fc-6413177b-e99c-4476-b085-3da80d320081/RiskScoreAdjustmentFiles/WallacesPCASites/sorted_thousand_genomes_wallace_sites.pc.meansd"
 	  File? population_pcs = "gs://fc-6413177b-e99c-4476-b085-3da80d320081/RiskScoreAdjustmentFiles/WallacesPCASites/sorted_thousand_genomes_wallace_sites.pc"
 	  File? pruning_sites_for_pca = "gs://fc-6413177b-e99c-4476-b085-3da80d320081/RiskScoreAdjustmentFiles/WallacesPCASites/wallace_pruning_sites_sorted_ids.txt"
+	  File? population_scoring_sites
 	  
 
 	  ## The following are inputs for scoring and performing the adjustment
@@ -66,9 +67,8 @@ workflow EndToEndPipeline {
   	    population_vcf = population_vcf,
   	    population_vcf_index = population_vcf_index,
   	    basename = population_basename,
-  	    original_array_vcf =  multi_sample_vcf,
-  	    original_array_vcf_index = multi_sample_vcf_index,
-  	    bad_variant_id_format = true # it will update the variant ids into the format we use: chr:pos:allele1:allele2
+  	    imputed_array_vcf =  ImputationSteps.imputed_multisample_vcf,
+  	    imputed_array_vcf_index = ImputationSteps.imputed_multisample_vcf_index,
     }
   }
 
@@ -86,6 +86,7 @@ workflow EndToEndPipeline {
 	    population_meansd = select_first([PopulationPCASteps.population_meansd, population_meansd]), 
 	    population_pcs = select_first([PopulationPCASteps.population_pcs, population_pcs]),
 	    pruning_sites_for_pca = select_first([PopulationPCASteps.pruning_sites_for_pca, pruning_sites_for_pca]),
+	    population_scoring_sites = select_first([PopulationPCASteps.population_sites_for_scoring, population_scoring_sites])
 	}
 
 	output {

--- a/ImputationPipeline/PerformPopulationPCA.wdl
+++ b/ImputationPipeline/PerformPopulationPCA.wdl
@@ -57,14 +57,14 @@ workflow PerformPopulationPCA {
           output_basename = basename
     }
 
-#  call SubsetToArrayVCF {
-#    input:
-#        vcf = SortVariantIds.output_vcf,
-#        vcf_index = SortVariantIds.output_vcf_index,
-#        intervals = SelectTypedSites.output_vcf,
-#        intervals_index = SelectTypedSites.output_vcf_index,
-#        basename = basename + ".sorted_ids.subsetted"
-#  }
+  call SubsetToArrayVCF {
+    input:
+        vcf = SortVariantIds.output_vcf,
+        vcf_index = SortVariantIds.output_vcf_index,
+        intervals = SelectTypedSites.output_vcf,
+        intervals_index = SelectTypedSites.output_vcf_index,
+        basename = basename + ".sorted_ids.subsetted"
+  }
  
   # this performs some basic QC steps (filtering by MAF, HWE, etc.), as well as 
   # generating a plink-style bim,bed,fam format that has been limited to LD pruned
@@ -107,8 +107,6 @@ workflow PerformPopulationPCA {
     File sorted_variant_id_dataset = SortVariantIds.output_vcf # this is what you should use as your population dataset for the 
     # ScoringPart, since all the IDs will be matching 
     File sorted_variant_id_dataset_index = SortVariantIds.output_vcf_index
-    File population_sites_for_scoring = ExtractIDsAll.ids
-
   }
 }
 

--- a/ImputationPipeline/PerformPopulationPCA.wdl
+++ b/ImputationPipeline/PerformPopulationPCA.wdl
@@ -120,6 +120,7 @@ task LDPruning {
     --extract ~{original_array_sites} \
     --indep-pairwise 1000 50 0.2 \
     --maf 0.01 \
+    --allow-extra-chr \
     --not-chr X \
     --out ~{basename} 
 
@@ -128,6 +129,7 @@ task LDPruning {
     --keep-allele-order \
     --extract ~{basename}.prune.in \
     --make-bed \
+    --allow-extra-chr \
     --not-chr X \
     --out ~{basename}
 
@@ -276,6 +278,7 @@ task LDPruneToSites {
     --keep-allele-order \
     --extract ~{pruning_sites} \
     --make-bed \
+    --allow-extra-chr \
     --out ~{basename}
   }
 

--- a/ImputationPipeline/PerformPopulationPCA.wdl
+++ b/ImputationPipeline/PerformPopulationPCA.wdl
@@ -57,14 +57,14 @@ workflow PerformPopulationPCA {
           output_basename = basename
     }
 
-  call SubsetToArrayVCF {
-    input:
-        vcf = SortVariantIds.output_vcf,
-        vcf_index = SortVariantIds.output_vcf_index,
-        intervals = SelectTypedSites.output_vcf,
-        intervals_index = SelectTypedSites.output_vcf_index,
-        basename = basename + ".sorted_ids.subsetted"
-  }
+#  call SubsetToArrayVCF {
+#    input:
+#        vcf = SortVariantIds.output_vcf,
+#        vcf_index = SortVariantIds.output_vcf_index,
+#        intervals = SelectTypedSites.output_vcf,
+#        intervals_index = SelectTypedSites.output_vcf_index,
+#        basename = basename + ".sorted_ids.subsetted"
+#  }
  
   # this performs some basic QC steps (filtering by MAF, HWE, etc.), as well as 
   # generating a plink-style bim,bed,fam format that has been limited to LD pruned
@@ -72,7 +72,7 @@ workflow PerformPopulationPCA {
   # you can run the LDPruneToSites task that is at the bottom of this wdl
   call LDPruning {
     input:
-      vcf = SubsetToArrayVCF.output_vcf,
+      vcf = SortVariantIds.output_vcf,
       basename = basename,
       original_array_sites = ExtractIDsTyped.ids
   }

--- a/ImputationPipeline/PerformPopulationPCA.wdl
+++ b/ImputationPipeline/PerformPopulationPCA.wdl
@@ -72,7 +72,7 @@ workflow PerformPopulationPCA {
   # you can run the LDPruneToSites task that is at the bottom of this wdl
   call LDPruning {
     input:
-      vcf = SortVariantIds.output_vcf,
+      vcf = SubsetToArrayVCF.output_vcf,
       basename = basename,
       original_array_sites = ExtractIDsTyped.ids
   }

--- a/ImputationPipeline/PerformPopulationPCA.wdl
+++ b/ImputationPipeline/PerformPopulationPCA.wdl
@@ -251,7 +251,7 @@ task ExtractIDs {
     input {
         File vcf
         String output_basename
-        Int disk_size = 2*ceil(size(vcf, "GB"))
+        Int disk_size = 2*ceil(size(vcf, "GB")) + 100
     }
 
     command <<<

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -185,7 +185,7 @@ task ArrayVcfToPlinkDataset {
 
 	command {
 
-		/plink2 --vcf ~{vcf} --extract-intersect ~{pruning_sites} ~{"--extract-intersect " + subset_to_sites} --allow-extra-chr \
+		/plink2 --vcf ~{vcf} --extract-intersect ~{pruning_sites} ~{subset_to_sites} --allow-extra-chr \
 		--out ~{basename} --make-bed --rm-dup force-first
 	}
 

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -134,8 +134,8 @@ task ScoreVcf {
 
 	command {
 		/plink2 --score ~{weights} header ignore-dup-ids list-variants-zs no-mean-imputation \
-		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --allow-extra-chr ~{extra_args} -vcf ~{vcf} ~{"-extract " + sites} \
-		dosage=DS --out ~{basename} --memory ~{plink_mem} 
+		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --allow-extra-chr ~{extra_args} -vcf ~{vcf} dosage=DS \
+		~{"-extract " + sites} --out ~{basename} --memory ~{plink_mem}
 	}
 
 	output {

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -125,7 +125,7 @@ task ScoreVcf {
 
 	command {
 		/plink2 --score ~{weights} header ignore-dup-ids list-variants-zs no-mean-imputation \
-		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums ~{extra_args} -vcf ~{vcf} \
+		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --allow-extra-chr ~{extra_args} -vcf ~{vcf} \
 		dosage=DS --out ~{basename} --memory ~{plink_mem} 
 	}
 
@@ -156,7 +156,7 @@ task ArrayVcfToPlinkDataset {
 
 	command {
 
-		/plink2 --vcf ~{vcf} --extract ~{pruning_sites} \
+		/plink2 --vcf ~{vcf} --extract ~{pruning_sites} --allow-extra-chr \
 		--out ~{basename} --make-bed --rm-dup force-first
 	}
 

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -134,7 +134,7 @@ task ScoreVcf {
 
 	command {
 		/plink2 --score ~{weights} header ignore-dup-ids list-variants-zs no-mean-imputation \
-		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --allow-extra-chr ~{extra_args} -vcf ~{vcf} ~{"-extract " + sites}\
+		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --allow-extra-chr ~{extra_args} -vcf ~{vcf} ~{"-extract " + sites} \
 		dosage=DS --out ~{basename} --memory ~{plink_mem} 
 	}
 

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -20,7 +20,6 @@ workflow ScoringImputedDataset {
     File population_pcs
     File pruning_sites_for_pca # and the sites used for PCA
     File population_vcf # population VCF, output from PerformPopulationPCA
-    File population_scoring_sites # sites to use for scoring population, from PerformPopulationPCA
 
     File adjust_scores_rscript = "gs://fc-6413177b-e99c-4476-b085-3da80d320081/ScoringAdjustment.R" 
     String? columns_for_scoring # Plink expects the first 3 columns in your weights file to be variant ID, effect allele, effect weight
@@ -39,6 +38,12 @@ workflow ScoringImputedDataset {
   	extra_args = columns_for_scoring
   }
 
+  call ExtractIDs {
+  	input:
+  		vcf = imputed_array_vcf,
+  		output_basename = basename
+  }
+
   call ScoreVcf as ScorePopulation {
   	input:
   	vcf = population_vcf,
@@ -46,7 +51,7 @@ workflow ScoringImputedDataset {
   	weights = weights,
   	base_mem = population_scoring_mem,
   	extra_args = columns_for_scoring,
-  	sites = population_scoring_sites
+  	sites = ExtractIDs.ids
   }
 
   call ArrayVcfToPlinkDataset {
@@ -291,4 +296,25 @@ task SortWeights {
  		memory: "16 GB"
  	}
  }
+
+ task ExtractIDs {
+     input {
+         File vcf
+         String output_basename
+         Int disk_size = 2*ceil(size(vcf, "GB")) + 100
+     }
+
+     command <<<
+         bcftools query -f "%ID\n" ~{vcf} -o ~{output_basename}.original_array.ids
+     >>>
+     output {
+         File ids = "~{output_basename}.original_array.ids"
+     }
+     runtime {
+         docker: "biocontainers/bcftools:v1.9-1-deb_cv1"
+         disks: "local-disk " + disk_size + " HDD"
+         memory: "4 GB"
+     }
+ }
+
 

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -135,7 +135,7 @@ task ScoreVcf {
 	command {
 		/plink2 --score ~{weights} header ignore-dup-ids list-variants-zs no-mean-imputation \
 		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --allow-extra-chr ~{extra_args} -vcf ~{vcf} dosage=DS \
-		~{"-extract " + sites} --out ~{basename} --memory ~{plink_mem}
+		~{"--extract " + sites} --out ~{basename} --memory ~{plink_mem}
 	}
 
 	output {

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -134,7 +134,7 @@ task ScoreVcf {
 
 	command {
 		/plink2 --score ~{weights} header ignore-dup-ids list-variants-zs no-mean-imputation \
-		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --allow-extra-chr ~{extra_args} -vcf ~{vcf} ~{"-extract" + sites}\
+		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --allow-extra-chr ~{extra_args} -vcf ~{vcf} ~{"-extract " + sites}\
 		dosage=DS --out ~{basename} --memory ~{plink_mem} 
 	}
 


### PR DESCRIPTION
This PR improves our implementation of using only typed sites for PCA, which had been our objective in the past, but had not been perfectly implemented.  Also adds the ability to redo the PCA calculation when scoring a sample, and also enforces that population scoring is done only over sites genotyped in the sample.  This is needed in a situation where the different samples may not have genotyped exactly all of the same sites, such as when scoring a wgs.  