### PR TITLE
Massive speedup on large cohorts

### DIFF
--- a/ImputationPipeline/Imputation.wdl
+++ b/ImputationPipeline/Imputation.wdl
@@ -202,7 +202,7 @@ task GenerateChunk {
      --select-type-to-exclude MIXED --restrict-alleles-to BIALLELIC -L ~{chrom}:~{start}-~{end} -O ~{basename}.vcf.gz --exclude-filtered true
   }
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.1.1.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.1.9.0"
     disks: "local-disk " + disk_size + " HDD"
     memory: "8 GB"
   }
@@ -408,7 +408,7 @@ task RemoveSymbolicAlleles {
     File output_vcf_index = "~{output_basename}.vcf.gz.tbi"
   }
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.1.7.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.1.9.0"
     disks: "local-disk " + disk_size + " HDD"
     memory: "4 GB"
   }
@@ -447,7 +447,7 @@ task SplitSample {
     gatk SelectVariants -V ~{vcf} -sn ~{sample} -O ~{sample}.vcf.gz
   }
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.1.1.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.1.9.0"
     disks: "local-disk " + disk_size + " HDD"
     memory: "9 GB"
   }

--- a/ImputationPipeline/PerformPopulationPCA.wdl
+++ b/ImputationPipeline/PerformPopulationPCA.wdl
@@ -129,7 +129,7 @@ task SelectTypedSites {
 	>>>
 
 	runtime {
-	docker: "us.gcr.io/broad-gatk/gatk:4.1.7.0"
+	docker: "us.gcr.io/broad-gatk/gatk:4.1.9.0"
 	disks: "local-disk " + disk_size + " HDD"
 	memory: "16 GB"
   }
@@ -398,7 +398,7 @@ task SubsetToArrayVCF {
    }
 
   runtime {
-    docker: "us.gcr.io/broad-gatk/gatk:4.1.1.0"
+    docker: "us.gcr.io/broad-gatk/gatk:4.1.9.0"
     disks: "local-disk " + disk_size + " HDD"
     memory: "4.5 GB"
   }


### PR DESCRIPTION
RemoveMultiallelics is a major bottleneck when running on large cohorts (1000+ samples) due to a regression which was fixed in broadinstitute/gatk#6729

This change takes advantage of the fix by bumping gatk version on SelectVariants tasks.  I expect a fairly massive time and money savings on large cohorts.

Additional optimization will be available by bumping the version again once broadinstitute/gatk#6754 is merged.