### PR TITLE
Update dockstore yml to include Benchmarking script

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -12,3 +12,6 @@ workflows:
   - name: PerformPopulationPCA
     subclass: WDL
     primaryDescriptorPath: /ImputationPipeline/PerformPopulationPCA.wdl
+  - name: BenchmarkVCFs
+    subclass: WDL
+    primaryDescriptorPath: /BenchmarkVCFs/BenchmarkVCFs.wdl


### PR DESCRIPTION
I now see this branch in the BenchmarkVCFs dockstore page (but none of the other branches). Perhaps once this is merged to main it will update all the branches? I'm not sure how to test that theory without merging it, but if someone else has ideas please let me know.