### PR TITLE
Fix validation workflow bug

### DIFF
--- a/ImputationPipeline/Validation/ValidateScoring.wdl
+++ b/ImputationPipeline/Validation/ValidateScoring.wdl
@@ -116,7 +116,7 @@ workflow ValidateScoring {
 			input:
 				arrayScores = select_first([ScoreImputed.adjusted_array_scores]),
 				wgsScores = select_first([ScoreWGS.adjusted_array_scores]),
-				arrayScoresMain = ScoreImputedMain.adjusted_array_scores,
+				arrayScoresMain = select_first([ScoreImputedMain.adjusted_array_scores]),
 				branch = branch,
 				sample_name_map = sample_name_map
 			}


### PR DESCRIPTION
Current iteration of pipeline fails in circleCI due to a missing `selectfirst`. Here's a proposed fix.