### PR TITLE
Score vcf memory change

### DIFF
--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -193,7 +193,6 @@ task ScoreVcf {
 		Int base_mem = 8
 		String? extra_args
 		File? sites
-		File monitoring_script = "gs://broad-dsde-methods-ckachulis/cromwell_monitoring_script/cromwell_monitoring_script.sh"
 	}
 
 	Int runtime_mem = base_mem + 2
@@ -201,7 +200,6 @@ task ScoreVcf {
 	Int disk_space =  3*ceil(size(vcf, "GB")) + 20 
 
 	command {
-		bash ~{monitoring_script} > monitoring.log &
 		/plink2 --score ~{weights} header ignore-dup-ids list-variants-zs no-mean-imputation \
 		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --allow-extra-chr ~{extra_args} -vcf ~{vcf} dosage=DS \
 		~{"--extract " + sites} --out ~{basename} --memory ~{plink_mem}
@@ -211,7 +209,6 @@ task ScoreVcf {
 		File score = "~{basename}.sscore"
 		File log = "~{basename}.log"
 		File sites_scored = "~{basename}.sscore.vars.zst"
-		File monitoring_log = "monitoring.log"
 	}
 
 	runtime {

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -193,6 +193,7 @@ task ScoreVcf {
 		Int base_mem = 8
 		String? extra_args
 		File? sites
+		File monitoring_script = "gs://broad-dsde-methods-ckachulis/cromwell_monitoring_script/cromwell_monitoring_script.sh"
 	}
 
 	Int runtime_mem = base_mem + 2
@@ -200,6 +201,7 @@ task ScoreVcf {
 	Int disk_space =  3*ceil(size(vcf, "GB")) + 20 
 
 	command {
+		bash ~{monitoring_script} > monitoring.log &
 		/plink2 --score ~{weights} header ignore-dup-ids list-variants-zs no-mean-imputation \
 		cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --allow-extra-chr ~{extra_args} -vcf ~{vcf} dosage=DS \
 		~{"--extract " + sites} --out ~{basename} --memory ~{plink_mem}
@@ -209,6 +211,7 @@ task ScoreVcf {
 		File score = "~{basename}.sscore"
 		File log = "~{basename}.log"
 		File sites_scored = "~{basename}.sscore.vars.zst"
+		File monitoring_log = "monitoring.log"
 	}
 
 	runtime {

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -196,7 +196,7 @@ task ScoreVcf {
 	}
 
 	Int runtime_mem = base_mem + 2
-	Int plink_mem = base_mem * 1000
+	Int plink_mem = ceil(base_mem * 0.75 * 1000)
 	Int disk_space =  3*ceil(size(vcf, "GB")) + 20 
 
 	command {


### PR DESCRIPTION
we need to make sure plink is given a memory argument that is less than the total memory given to the machine