### PR TITLE
Handle no-calls at APOl1 risk alleles in ckd adjustment

### DIFF
--- a/ImputationPipeline/CKDRiskAdjustment.wdl
+++ b/ImputationPipeline/CKDRiskAdjustment.wdl
@@ -63,10 +63,12 @@ task AdjustRisk {
     Rscript -<< "EOF"
       library(dplyr)
       library(readr)
+      library(tidyr)
 
       risk_allele_counts <- read_tsv("~{risk_allele_counts}")
       adjusted_scores <- read_tsv("~{adjusted_scores}")
 
+      risk_allele_counts <- risk_allele_counts %>% replace_na(list(.[[7]] = 0, .[[8]] = 0, .[[9]] = 0))
       risk_allele_counts <- risk_allele_counts %>% transmute(IID, apol1_high_risk = ifelse(pmax(.[[7]], .[[8]]) + .[[9]] >= 2, 1, 0))
       adjusted_scores <- inner_join(adjusted_scores, risk_allele_counts)
       adjusted_scores <- adjusted_scores %>% mutate(adjusted_score = adjusted_score + apol1_high_risk)

--- a/ImputationPipeline/CKDRiskAdjustment.wdl
+++ b/ImputationPipeline/CKDRiskAdjustment.wdl
@@ -68,8 +68,8 @@ task AdjustRisk {
       risk_allele_counts <- read_tsv("~{risk_allele_counts}")
       adjusted_scores <- read_tsv("~{adjusted_scores}")
 
-      risk_allele_counts <- risk_allele_counts %>% replace_na(list(.[[7]] = 0, .[[8]] = 0, .[[9]] = 0))
-      risk_allele_counts <- risk_allele_counts %>% transmute(IID, apol1_high_risk = ifelse(pmax(.[[7]], .[[8]]) + .[[9]] >= 2, 1, 0))
+      risk_allele_counts <- risk_allele_counts %>% mutate(G1_1 = replace_na(.[[7]], 0), G1_2 = replace_na(.[[8]], 0), G2 = replace_na(.[[9]], 0))
+      risk_allele_counts <- risk_allele_counts %>% transmute(IID, apol1_high_risk = ifelse(pmax(G1_1, G1_2) + G2 >= 2, 1, 0))
       adjusted_scores <- inner_join(adjusted_scores, risk_allele_counts)
       adjusted_scores <- adjusted_scores %>% mutate(adjusted_score = adjusted_score + apol1_high_risk)
       adjusted_scores <- adjusted_scores %>% mutate(percentile = pnorm(adjusted_score))


### PR DESCRIPTION
A no-call in the vcf will result in NA in the risk allele count file.  This pr then converts those NA's to 0, so treats no calls as 0 risk alleles.  

I haven't tested this yet at all, but I suspect the emerge 1-3 tests may hit this issue, so can be tested on that.

#61 