### PR TITLE
Edited FindSamplesAndBenchmark inputs JSON to match Terra's defaults

### DIFF
--- a/BenchmarkVCFs/FindSamplesAndBenchmark_input.json
+++ b/BenchmarkVCFs/FindSamplesAndBenchmark_input.json
@@ -9,7 +9,7 @@
   "FindSamplesAndBenchmark.input_labels": ["file1_condition1", "file2_condition2"],
   "FindSamplesAndBenchmark.picard_cloud_jar": "picard-2.23.6+.jar",
   "FindSamplesAndBenchmark.ref_fasta": "${workspace.referenceData_hg38_ref_fasta}",
-  "FindSamplesAndBenchmark.ref_fasta_dict": "${workspace.referenceData_hg38_ref_fasta_dict}",
+  "FindSamplesAndBenchmark.ref_fasta_dict": "${workspace.referenceData_hg38_ref_dict}",
   "FindSamplesAndBenchmark.ref_fasta_index": "${workspace.referenceData_hg38_ref_fasta_index}",
   "FindSamplesAndBenchmark.annotationNames": ["TandemRepeat"],
   "FindSamplesAndBenchmark.ref_fasta_sdf": " gs://broad-dsde-methods-hydro-gen-truth-data-public/reference/hg38/reference_sdf.tar",


### PR DESCRIPTION
This short commit changes the default input for FindSamplesAndBenchmark for the reference dict to match the default naming scheme used by Terra if one auto-generates the hg38 reference data in Terra. The former input JSON leads to an immediate "Expected single value for workflow input, but evaluated result set was empty" error in this situation, whereas the latter runs. 