### PR TITLE
Making the ExtractSample step faster for FindSamplesAndBenchmark

### DIFF
--- a/BenchmarkVCFs/FindSamplesAndBenchmark.wdl
+++ b/BenchmarkVCFs/FindSamplesAndBenchmark.wdl
@@ -308,7 +308,7 @@ task ExtractSampleFromCallset {
         set -xe
         mkdir out_dir
         bcftools +split ~{callset} -Oz -o out_dir -S ~{sampleNamesToExtract} -i'GT="alt"'
-        mv outdir/~{sample}.vcf.gz ~{basename}.vcf.gz
+        mv out_dir/~{sample}.vcf.gz ~{basename}.vcf.gz
         bcftools index -t ~{basename}.vcf.gz
     >>>
     output {


### PR DESCRIPTION
There is a step that extracts a single sample VCF from a joint callset in the FindSamplesAndBenchmark wdl. With larger callsets this step can take quite awhile. This speeds the process up by using bcftools and by not needed to index the file first.

Also adds the Terra call caching dummy variable to other tasks that don't take in sample specific data and therefore cache hit in Terra to workspaces the user doesn't have access to (meaning it fails to call cache).