### PR TITLE
Accidentally added an extra parameter while rebasing a previous commit

### DIFF
--- a/BenchmarkVCFs/FindSamplesAndBenchmark.wdl
+++ b/BenchmarkVCFs/FindSamplesAndBenchmark.wdl
@@ -34,7 +34,6 @@ workflow FindSamplesAndBenchmark {
         Boolean doIndelLengthStratification=false
         Boolean requireMatchingGenotypes=true
 
-        String vcfScoreField="INFO.TREE_SCORE"
         String referenceVersion = "1"
         String gatkTag = "4.0.11.0"
 


### PR DESCRIPTION
This removes the extra copy of the parameter. This was introduced in #65 