### PR TITLE
PRS Reportable Range Check

### DIFF
--- a/ImputationPipeline/PRSWrapper.wdl
+++ b/ImputationPipeline/PRSWrapper.wdl
@@ -121,7 +121,7 @@ task SelectValuesOfInterest {
     reason_not_resulted <- ifelse(abs(adjusted_score) > ~{z_score_reportable_range},
                                 ifelse(adjusted_score > 0, paste("Z-SCORE ABOVE + ", z_score_reportable_range),
                                                            paste("Z-SCORE BELOW - ", z_score_reportable_range)
-                                      )
+                                      ),
                                 "NA"
                                 )
 

--- a/ImputationPipeline/PRSWrapper.wdl
+++ b/ImputationPipeline/PRSWrapper.wdl
@@ -119,8 +119,8 @@ task SelectValuesOfInterest {
     percentile_output <- ifelse(abs(adjusted_score) > ~{z_score_reportable_range}, "NOT_RESULTED", percentile)
     risk_output <- ifelse(abs(adjusted_score) > ~{z_score_reportable_range}, "NOT_RESULTED", risk)
     reason_not_resulted <- ifelse(abs(adjusted_score) > ~{z_score_reportable_range},
-                                ifelse(adjusted_score > 0, paste("Z-SCORE ABOVE + ", z_score_reportable_range),
-                                                           paste("Z-SCORE BELOW - ", z_score_reportable_range)
+                                ifelse(adjusted_score > 0, paste("Z-SCORE ABOVE + ", ~{z_score_reportable_range}),
+                                                           paste("Z-SCORE BELOW - ", ~{z_score_reportable_range})
                                       ),
                                 "NA"
                                 )


### PR DESCRIPTION
In PRSWrapper, If PRS z-scores is outside defined reportable range, results are changed to "NOT_RESULTED" and reason is recorded in "~{condition}_not_resulted_reason" column.