### PR TITLE
Add Interaction terms to PRS pipeline 

### DIFF
--- a/ImputationPipeline/EndToEndPipeline.wdl
+++ b/ImputationPipeline/EndToEndPipeline.wdl
@@ -3,6 +3,7 @@ version 1.0
 import "Imputation.wdl" as imputation_pipeline
 import "ScoringPart.wdl" as scoring_pipeline
 import "PerformPopulationPCA.wdl" as population_pipeline # Like Thousand Genomes
+import "Structs.wdl" as Structs
 
 workflow EndToEndPipeline {
 	input {
@@ -39,7 +40,7 @@ workflow EndToEndPipeline {
 
 	  ## The following are inputs for scoring and performing the adjustment
 
-	  File disease_weights  # disease weights file. Because we use variant IDs with sorted alleles, there is a task at the bottom of this workflow
+	  WeightSet disease_weights  # disease weights file. Because we use variant IDs with sorted alleles, there is a task at the bottom of this workflow
 	  String? columns_for_scoring # Plink expects the first 3 columns in your weights file to be variant ID, effect allele, effect weight
 	  
 	  Int scoring_mem = 16 # update memory for scoring imputed array
@@ -73,7 +74,7 @@ workflow EndToEndPipeline {
 
   call scoring_pipeline.ScoringImputedDataset as ScoringSteps {
 	  input :
-		weights  = disease_weights,
+		weight_set  = disease_weights,
 		columns_for_scoring = columns_for_scoring,
 		imputed_array_vcf = ImputationSteps.imputed_multisample_vcf,
 	    scoring_mem = scoring_mem,

--- a/ImputationPipeline/PRSWrapper.wdl
+++ b/ImputationPipeline/PRSWrapper.wdl
@@ -28,7 +28,7 @@ workflow PRSWrapper {
   if (length(named_weight_sets) != length(score_condition) || length(named_weight_sets) != length(percentile_thresholds)) {
     call ErrorWithMessage {
       input:
-        message = "named_weight_sets, score_condition, and percentile_thresholds"
+        message = "named_weight_sets, score_condition, and percentile_thresholds must all be same length"
     }
   }
 

--- a/ImputationPipeline/PRSWrapper.wdl
+++ b/ImputationPipeline/PRSWrapper.wdl
@@ -5,14 +5,11 @@ import "Structs.wdl"
 
 workflow PRSWrapper {
   input {
-    Array[String] condition_names
+    Array[NamedWeightSet] named_weight_sets
     Array[Boolean] score_condition
     Array[Float] percentile_thresholds
-    Array[File] weights_files
     File ckd_risk_alleles
     Float z_score_reportable_range
-    File t1d_interaction_weights
-    SelfExclusiveSites t1d_interaction_self_exclusive_sites
 
     File vcf
     String sample_id
@@ -28,22 +25,18 @@ workflow PRSWrapper {
     String population_basename
   }
 
-  if (length(condition_names) != length(score_condition) || length(condition_names) != length(weights_files) || length(condition_names) != length(percentile_thresholds)) {
+  if (length(named_weight_sets) != length(score_condition) || length(named_weight_sets) != length(percentile_thresholds)) {
     call ErrorWithMessage {
       input:
-        message = "conditions_names, use_condition, use_ancestry_correction, and weights_files must all be arrays of the same length"
+        message = "named_weight_sets, score_condition, and percentile_thresholds"
     }
   }
 
-  scatter(i in range(length(condition_names))) {
+  scatter(i in range(length(named_weight_sets))) {
     if (score_condition[i]) {
-      if (condition_names[i] == "t1d") {
-        File interaction_weights = t1d_interaction_weights
-        SelfExclusiveSites interaction_self_exclusive_sites = t1d_interaction_self_exclusive_sites
-      }
       call Score.ScoringImputedDataset {
         input:
-          weights = weights_files[i],
+          weight_set = named_weight_sets[i].weight_set,
           imputed_array_vcf = vcf,
           population_loadings = population_loadings,
           population_meansd = population_meansd,
@@ -52,12 +45,10 @@ workflow PRSWrapper {
           population_vcf = population_vcf,
           basename = sample_id,
           population_basename = population_basename,
-          redoPCA = redoPCA,
-          interaction_weights = interaction_weights,
-          interaction_self_exclusive_sites = interaction_self_exclusive_sites
+          redoPCA = redoPCA
       }
 
-      if (condition_names[i] == "ckd") {
+      if (named_weight_sets[i].condition_name == "ckd") {
         call CKDRiskAdjustment.CKDRiskAdjustment {
           input:
             adjustedScores = select_first([ScoringImputedDataset.adjusted_array_scores]),
@@ -71,7 +62,7 @@ workflow PRSWrapper {
         input:
           score_result = select_first([CKDRiskAdjustment.adjusted_scores_with_apol1, ScoringImputedDataset.adjusted_array_scores]),
           sample_id = sample_id,
-          condition_name = condition_names[i],
+          condition_name = named_weight_sets[i].condition_name,
           threshold = percentile_thresholds[i],
           z_score_reportable_range = z_score_reportable_range
       }
@@ -82,7 +73,7 @@ workflow PRSWrapper {
       call CreateUnscoredResult {
         input:
           sample_id = sample_id,
-          condition_name = condition_names[i]
+          condition_name = named_weight_sets[i].condition_name
       }
     }
 
@@ -101,6 +92,7 @@ workflow PRSWrapper {
     File pcs = select_first(ScoringImputedDataset.pc_projection)
   }
 }
+
 
 task SelectValuesOfInterest {
   input {

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -312,7 +312,7 @@ task AddInteractionTermsToScore {
 
 					add_allele_to_count(site_1, allele_1, interactions_allele_counts)
 					add_allele_to_count(site_2, allele_2, interactions_allele_counts)
-					interaction_idct[(site_1, allele_1, site_2, allele_2)] = weight
+					interaction_dict[(site_1, allele_1, site_2, allele_2)] = weight
 					positions.add((chrom_1, pos_1))
 					positions.add((chrom_2, pos_2))
 

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -391,7 +391,7 @@ task AddInteractionTermsToScore {
 
 		#add interaction scores to linear scores
 		df_interaction_score = pd.DataFrame({"sample_id":samples, "interaction_score":interaction_scores}).set_index("sample_id")
-		df_scores=pd.read_csv("~{scores}", sep="\t").astype({'#IID#':'string'}).set_index("#IID")
+		df_scores=pd.read_csv("~{scores}", sep="\t").astype({'#IID':'string'}).set_index("#IID")
 		df_scores = df_scores.join(df_interaction_score)
 		df_scores['SCORE1_SUM'] = df_scores['SCORE1_SUM'] + df_scores['interaction_score']
 		df_scores.to_csv("~{basename}_scores_with_interactions.tsv", sep="\t")

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -297,11 +297,11 @@ task AddInteractionTermsToScore {
 		with open("~{interaction_weights}") as f:
 			for line in f:
 				line_split = line.split()
-			if weight := read_as_float(line_split[8]):
-				if len(sites) == 0 or line_split[0] in sites and line_split[4] in sites:
-					add_allele_to_count(line_split[0], line_split[3], interactions_allele_counts)
-					add_allele_to_count(line_split[4], line_split[7], interactions_allele_counts)
-					interactions_dict[(line_split[0], line_split[3], line_split[4], line_split[7])]=weight
+				if weight := read_as_float(line_split[8]):
+					if len(sites) == 0 or line_split[0] in sites and line_split[4] in sites:
+						add_allele_to_count(line_split[0], line_split[3], interactions_allele_counts)
+						add_allele_to_count(line_split[4], line_split[7], interactions_allele_counts)
+						interactions_dict[(line_split[0], line_split[3], line_split[4], line_split[7])]=weight
 
 		print("len(sites) = " + str(len(sites)))
 		print(interactions_dict)

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -288,7 +288,7 @@ task AddInteractionTermsToScore {
 		positions = set()
 		if ~{if defined(sites) then "True" else "False"}:
 			with open("~{sites}") as f_sites:
-				sites = {s for s in f_sites}
+				sites = {s.strip() for s in f_sites}
 		else:
 			sites = {}
 		with open("~{interaction_weights}") as f:

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -271,6 +271,9 @@ task AddInteractionTermsToScore {
 		from cyvcf2 import VCF
 		import pandas as pd
 
+		vcf = VCF("~{vcf}", lazy=True)
+		samples = vcf.samples
+
 		def read_as_float(s):
 			try:
 				return float(s)
@@ -302,8 +305,6 @@ task AddInteractionTermsToScore {
 
 		#count interaction alleles for each sample
 		count = 0
-		vcf = VCF("~{vcf}", lazy=True)
-		samples = vcf.samples
 		for variant in vcf:
 			if count % 100_000 == 0:
 				print(variant.CHROM + ":" + str(variant.POS))

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -278,6 +278,7 @@ task AddInteractionTermsToScore {
 		python3 << "EOF"
 		from cyvcf2 import VCF
 		import pandas as pd
+		import csv
 
 		vcf = VCF("~{vcf}", lazy=True)
 		samples = vcf.samples

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -312,7 +312,7 @@ task AddInteractionTermsToScore {
 
 					add_allele_to_count(site_1, allele_1, interactions_allele_counts)
 					add_allele_to_count(site_2, allele_2, interactions_allele_counts)
-					interaction_dict[(site_1, allele_1, site_2, allele_2)] = weight
+					interactions_dict[(site_1, allele_1, site_2, allele_2)] = weight
 					positions.add((chrom_1, pos_1))
 					positions.add((chrom_2, pos_2))
 

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -724,7 +724,7 @@ task ExtractIDsPlink {
 	Int plink_mem = ceil(mem * 0.75 * 1000)
 
 	command <<<
-		/plink2 --vcf ~{vcf} --set-all-var-ids @:#:\$1:\$2 --new-id-max-allele-len 1000 missing --write-snplist allow-dups --memory ~{plink_mem}
+		/plink2 --vcf ~{vcf} --set-all-var-ids @:#:\$1:\$2 --new-id-max-allele-len 1000 missing --allow-extra-chr --write-snplist allow-dups --memory ~{plink_mem}
 	>>>
 	output {
 		File ids = "plink2.snplist"

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -302,15 +302,15 @@ task AddInteractionTermsToScore {
 
 		#count interaction alleles for each sample
 		count = 0
-		with vcf = VCF("~{vcf}", lazy=True):
-			samples = vcf.samples
-			for variant in vcf:
-				if count % 100_000 == 0:
-					print(variant.CHROM + ":" + variant.POS)
-				count += 1
+		vcf = VCF("~{vcf}", lazy=True):
+		samples = vcf.samples
+		for variant in vcf:
+			if count % 100_000 == 0:
+				print(variant.CHROM + ":" + variant.POS)
+			count += 1
 
-				alleles = [a for a_l in [[variant.REF], variant.ALT] for a in a_l]
-				vid=":".join(s for s_l in [[variant.CHROM], [str(variant.POS)], sorted(alleles)] for s in s_l)
+			alleles = [a for a_l in [[variant.REF], variant.ALT] for a in a_l]
+			vid=":".join(s for s_l in [[variant.CHROM], [str(variant.POS)], sorted(alleles)] for s in s_l)
 			if vid in interactions_allele_counts:
 				for sample_i,gt in enumerate(variant.genotypes):
 					for gt_allele in gt[:-1]:

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -289,7 +289,7 @@ task AddInteractionTermsToScore {
 		if ~{if defined(sites) then "True" else "False"}:
 			with open("~{sites}") as f_sites:
 				sites = {s for s in f_sites}
-		else
+		else:
 			sites = {}
 		with open("~{interaction_weights}") as f:
 			for line in f:

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -303,13 +303,11 @@ task AddInteractionTermsToScore {
 					add_allele_to_count(line_split[4], line_split[7], interactions_allele_counts)
 					interactions_dict[(line_split[0], line_split[3], line_split[4], line_split[7])]=weight
 
-		#count interaction alleles for each sample
-		count = 0
-		for variant in vcf:
-			if count % 100_000 == 0:
-				print(variant.CHROM + ":" + str(variant.POS))
-			count += 1
+		print("len(sites) = " + str(len(sites)))
+		print(interactions_dict)
 
+		#count interaction alleles for each sample
+		for variant in vcf:
 			alleles = [a for a_l in [[variant.REF], variant.ALT] for a in a_l]
 			vid=":".join(s for s_l in [[variant.CHROM], [str(variant.POS)], sorted(alleles)] for s in s_l)
 			if vid in interactions_allele_counts:
@@ -318,6 +316,8 @@ task AddInteractionTermsToScore {
 						allele = alleles[gt_allele]
 					if allele in interactions_allele_counts[vid]:
 						interactions_allele_counts[vid][allele][sample_i] += 1
+
+		print(interactions_allele_counts)
 
 		#calculate interaction scores for each sample
 		interaction_scores = [0] * len(samples)

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -332,7 +332,7 @@ task AddInteractionTermsToScore {
 					chrom = line['chrom']
 					pos = line['pos']
 					allele = line['allele']
-					add_self_exclusive_sites(id, allele, self_exclusive_sites)
+					add_self_exclusive_site(id, allele, self_exclusive_sites)
 					positions.add((chrom, pos))
 
 		#select blocks to read

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -262,6 +262,7 @@ task AddInteractionTermsToScore {
 		String basename
 
 		Float mem = 8
+		Int threads = 4
 	}
 
 	Int disk_space =  3*ceil(size(vcf, "GB")) + 20
@@ -271,7 +272,7 @@ task AddInteractionTermsToScore {
 		from cyvcf2 import VCF
 		import pandas as pd
 
-		vcf = VCF("~{vcf}", lazy=True)
+		vcf = VCF("~{vcf}", lazy=True, threads=~{threads})
 		samples = vcf.samples
 
 		def read_as_float(s):
@@ -347,6 +348,7 @@ task AddInteractionTermsToScore {
 		docker: "us.gcr.io/broad-dsde-methods/imputation_interaction_python:v1.0.0"
 		disks: "local-disk " + disk_space + " HDD"
 		memory: mem + " GB"
+		cpu: threads
 	}
 
 	output {

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -313,7 +313,7 @@ task AddInteractionTermsToScore {
 					add_allele_to_count(site_2, allele_2, interactions_allele_counts)
 					interaction_idct[(site_1, allele_1, site_2, allele_2)] = weight
 					positions.add((chrom_1, pos_1))
-					positions.add(chrom_2, pos_2))
+					positions.add((chrom_2, pos_2))
 
 		def add_self_exclusive_site(site, allele, dictionary):
 			if site in dictionary:

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -308,14 +308,15 @@ task AddInteractionTermsToScore {
 			sites = {}
 		with open("~{interaction_weights}") as f:
 			for line in f:
-				line_split = line.split()
-				if weight := read_as_float(line_split[8]):
-					if len(sites) == 0 or line_split[0] in sites and line_split[4] in sites:
-						add_allele_to_count(line_split[0], line_split[3], interactions_allele_counts)
-						add_allele_to_count(line_split[4], line_split[7], interactions_allele_counts)
-						interactions_dict[(line_split[0], line_split[3], line_split[4], line_split[7])]=weight
-						positions.add((line_split[1], int(line_split[2])))
-						positions.add((line_split[5], int(line_split[6])))
+				if line.strip():
+					line_split = line.split()
+					if weight := read_as_float(line_split[8]):
+						if len(sites) == 0 or line_split[0] in sites and line_split[4] in sites:
+							add_allele_to_count(line_split[0], line_split[3], interactions_allele_counts)
+							add_allele_to_count(line_split[4], line_split[7], interactions_allele_counts)
+							interactions_dict[(line_split[0], line_split[3], line_split[4], line_split[7])]=weight
+							positions.add((line_split[1], int(line_split[2])))
+							positions.add((line_split[5], int(line_split[6])))
 
 		def add_self_exclusive_site(site, allele, dictionary):
 			if site in dictionary:
@@ -329,9 +330,10 @@ task AddInteractionTermsToScore {
 		if ~{if (defined(self_exclusive_sites)) then "True" else "False"}:
 			with open("~{select_first([self_exclusive_sites]).sites}") as f_self_exclusive_sites:
 				for line in f_self_exclusive_sites:
-					line_split = line.split()
-					self_exclusive_sites[line_split[0]] = line_split[3]
-					positions.add((line_split[1], int(line_split[2])))
+					if line.strip():
+						line_split = line.split()
+						add_self_exclusive_site(line_split[0], line_split[3], self_exclusive_sites)
+						positions.add((line_split[1], int(line_split[2])))
 
 		#select blocks to read
 		positions = sorted(positions)

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -330,7 +330,7 @@ task AddInteractionTermsToScore {
 				for line in csv.DictReader(f_self_exclusive_sites, delimiter='\t'):
 					id = line['id']
 					chrom = line['chrom']
-					pos = line['pos']
+					pos = int(line['pos'])
 					allele = line['allele']
 					add_self_exclusive_site(id, allele, self_exclusive_sites)
 					positions.add((chrom, pos))

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -382,7 +382,7 @@ task AddInteractionTermsToScore {
 
 		for interaction in interactions_dict:
 			for sample_i in range(len(samples)):
-				if self_exclusive_sites_counts[sample_i] <= max_self_exclusive_sites
+				if self_exclusive_sites_counts[sample_i] <= max_self_exclusive_sites:
 					site_and_allele_1 = (interaction[0], interaction[1])
 					site_and_allele_2 = (interaction[2], interaction[3])
 					interaction_scores[sample_i]+=get_interaction_count(site_and_allele_1, site_and_allele_2, sample_i) * interactions_dict[interaction]

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -302,7 +302,7 @@ task AddInteractionTermsToScore {
 
 		#count interaction alleles for each sample
 		count = 0
-		vcf = VCF("~{vcf}", lazy=True):
+		vcf = VCF("~{vcf}", lazy=True)
 		samples = vcf.samples
 		for variant in vcf:
 			if count % 100_000 == 0:

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -391,7 +391,7 @@ task AddInteractionTermsToScore {
 
 		#add interaction scores to linear scores
 		df_interaction_score = pd.DataFrame({"sample_id":samples, "interaction_score":interaction_scores}).set_index("sample_id")
-		df_scores=pd.read_csv("~{scores}", sep="\t").astype('string').set_index("#IID")
+		df_scores=pd.read_csv("~{scores}", sep="\t").astype({'#IID#':'string'}).set_index("#IID")
 		df_scores = df_scores.join(df_interaction_score)
 		df_scores['SCORE1_SUM'] = df_scores['SCORE1_SUM'] + df_scores['interaction_score']
 		df_scores.to_csv("~{basename}_scores_with_interactions.tsv", sep="\t")

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -306,7 +306,7 @@ task AddInteractionTermsToScore {
 		samples = vcf.samples
 		for variant in vcf:
 			if count % 100_000 == 0:
-				print(variant.CHROM + ":" + variant.POS)
+				print(variant.CHROM + ":" + str(variant.POS))
 			count += 1
 
 			alleles = [a for a_l in [[variant.REF], variant.ALT] for a in a_l]

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -391,7 +391,7 @@ task AddInteractionTermsToScore {
 
 		#add interaction scores to linear scores
 		df_interaction_score = pd.DataFrame({"sample_id":samples, "interaction_score":interaction_scores}).set_index("sample_id")
-		df_scores=pd.read_csv("~{scores}", sep="\t").set_index("#IID")
+		df_scores=pd.read_csv("~{scores}", sep="\t").astype('string').set_index("#IID")
 		df_scores = df_scores.join(df_interaction_score)
 		df_scores['SCORE1_SUM'] = df_scores['SCORE1_SUM'] + df_scores['interaction_score']
 		df_scores.to_csv("~{basename}_scores_with_interactions.tsv", sep="\t")

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -364,7 +364,7 @@ task AddInteractionTermsToScore {
 							allele = alleles[gt_allele]
 							if allele in interactions_allele_counts[vid]:
 								interactions_allele_counts[vid][allele][sample_i] += 1
-				if vid in self_exclusive_sites
+				if vid in self_exclusive_sites:
 					for sample_i,gt in enumerate(variant.genotypes):
 						for gt_allele in gt[:-1]:
 							allele = alleles[gt_allele]

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -4,6 +4,7 @@ workflow ScoringImputedDataset {
 	input { 
 	File weights # disease weights file. Becauase we use variant IDs with sorted alleles, there is a task at the bottom of this workflow
 	#  that will allow you to sort the variants in this weights file (`SortWeights`)
+	File? interaction_weights # wieghts for snp interactions
 
 	File imputed_array_vcf  # imputed VCF for scoring (and optionally PCA projection): make sure the variant IDs exactly match those in the weights file
 	Int scoring_mem = 16
@@ -83,6 +84,17 @@ workflow ScoringImputedDataset {
 		sites = ExtractIDsPopulation.ids
 	}
 
+	if (defined(interaction_weights)) {
+		call AddInteractionTermsToScore {
+			input:
+				vcf = imputed_array_vcf,
+				interaction_weights = select_first([interaction_weights]),
+				scores = ScoreImputedArray.score,
+				sites = ExtractIDsPopulation.ids,
+				basename = basename
+		}
+	}
+
 	if (adjustScores) {
 		call ExtractIDsPlink {
 			input:
@@ -117,6 +129,17 @@ workflow ScoringImputedDataset {
 			sites = ExtractIDsPlink.ids
 		}
 
+		if (defined(interaction_weights)) {
+			call AddInteractionTermsToScore as AddInteractionTermsToScorePopulation {
+				input:
+					vcf = select_first([population_vcf]),
+					interaction_weights = select_first([interaction_weights]),
+					scores = ScorePopulation.score,
+					sites = ExtractIDsPlink.ids,
+					basename = select_first([population_basename])
+			}
+		}
+
 		call ArrayVcfToPlinkDataset {
 			input:
 			vcf = imputed_array_vcf,
@@ -144,9 +167,9 @@ workflow ScoringImputedDataset {
 		call AdjustScores {
 			input:
 			population_pcs = select_first([PerformPCA.pcs, population_pcs]),
-			population_scores = ScorePopulation.score,
+			population_scores = select_first([AddInteractionTermsToScorePopulation.scores_with_interactions, ScorePopulation.score]),
 			array_pcs = ProjectArray.projections,
-			array_scores = ScoreImputedArray.score
+			array_scores = select_first([AddInteractionTermsToScore.scores_with_interactions, ScoreImputedArray.score])
 		  }
 		if (!CheckPopulationIdsValid.files_are_valid) {
 			call ErrorWithMessage {
@@ -162,7 +185,7 @@ workflow ScoringImputedDataset {
 	File? adjusted_array_scores = AdjustScores.adjusted_array_scores
 	Boolean? fit_converged = AdjustScores.fit_converged
 	File? pc_projection = ProjectArray.projections
-	File raw_scores = ScoreImputedArray.score
+	File raw_scores = select_first([AddInteractionTermsToScore.scores_with_interactions, ScoreImputedArray.score])
   }
 }
 
@@ -227,6 +250,106 @@ task ScoreVcf {
 		docker: "skwalker/plink2:first"
 		disks: "local-disk " + disk_space + " HDD"
 		memory: runtime_mem + " GB"
+	}
+}
+
+task AddInteractionTermsToScore {
+	input {
+		File vcf
+		File interaction_weights
+		File scores
+		File? sites
+		String basename
+
+		Float mem = 8
+	}
+
+	Int disk_space =  3*ceil(size(vcf, "GB")) + 20
+
+	command <<<
+		python3 << "EOF"
+			from cyvcf2 import VCF
+			import pandas as pd
+
+			def read_as_float(s):
+				try:
+					return float(s)
+				except ValueError:
+					pass
+
+			def add_allele_to_count(site, allele, dictionary):
+				if site in dictionary:
+					dictionary[site][allele]=[0]*len(samples)
+				else:
+					dictionary[site]={allele:[0]*len(samples)}
+
+			interactions_allele_counts = dict()
+			interactions_dict = dict()
+			positions = set()
+			if ~{if defined(sites) then "True" else "False"}:
+				with open("~{sites}") as f_sites:
+					sites = {s for s in f_sites}
+			else
+				sites = {}
+			with open("~{interaction_weights}") as f:
+				for line in f:
+					line_split = line.split()
+				if weight := read_as_float(line_split[8]):
+					if len(sites) == 0 or line_split[0] in sites and line_split[4] in sites:
+						add_allele_to_count(line_split[0], line_split[3], interactions_allele_counts)
+						add_allele_to_count(line_split[4], line_split[7], interactions_allele_counts)
+						interactions_dict[(line_split[0], line_split[3], line_split[4], line_split[7])]=weight
+
+			#count interaction alleles for each sample
+			count = 0
+			with vcf = VCF("~{vcf}", lazy=True):
+				samples = vcf.samples
+				for variant in vcf:
+					if count % 100_000 == 0:
+						print(variant.CHROM + ":" + variant.POS)
+					count += 1
+
+					alleles = [a for a_l in [[variant.REF], variant.ALT] for a in a_l]
+					vid=":".join(s for s_l in [[variant.CHROM], [str(variant.POS)], sorted(alleles)] for s in s_l)
+				if vid in interactions_allele_counts:
+					for sample_i,gt in enumerate(variant.genotypes):
+						for gt_allele in gt[:-1]:
+							allele = alleles[gt_allele]
+						if allele in interactions_allele_counts[vid]:
+							interactions_allele_counts[vid][allele][sample_i] += 1
+
+			#calculate interaction scores for each sample
+			interaction_scores = [0] * len(samples)
+
+			def get_interaction_count(site_and_allele_1, site_and_allele_2, sample_i):
+				if site_and_allele_1 == site_and_allele_2:
+					return interactions_allele_counts[site_and_allele_1[0]][site_and_allele_1[1]][sample_i]//2
+				else:
+					return min(interactions_allele_counts[site_and_allele_1[0]][site_and_allele_1[1]][sample_i], interactions_allele_counts[site_and_allele_2[0]][site_and_allele_2[1]][sample_i])
+
+			for interaction in interactions_dict:
+				for sample_i in range(len(samples)):
+					site_and_allele_1 = (interaction[0], interaction[1])
+					site_and_allele_2 = (interaction[2], interaction[3])
+					interaction_scores[sample_i]+=get_interaction_count(site_and_allele_1, site_and_allele_2, sample_i) * interactions_dict[interaction]
+
+			#add interaction scores to linear scores
+			df_interaction_score = pd.DataFrame({"sample_id":samples, "interaction_score":interaction_scores}).set_index("sample_id")
+			df_scores=pd.read_csv("~{scores}", sep="\t").set_index("#IID")
+			df_scores = df_scores.join(df_interaction_score)
+			df_scores['SCORE1_SUM'] = df_scores['SCORE1_SUM'] + df_scores['interaction_score']
+			df_scores.to_csv("~{basename}_scores_with_interactions.tsv", sep="\t")
+		EOF
+	>>>
+
+	runtime {
+		docker: "us.gcr.io/broad-dsde-methods/imputation_interaction_python:v1.0.0"
+		disks: "local-disk " + disk_space + " HDD"
+		memory: mem + " GB"
+	}
+
+	output {
+		File scores_with_interactions = basename + "_scores_with_interactions.tsv"
 	}
 }
 

--- a/ImputationPipeline/Structs.wdl
+++ b/ImputationPipeline/Structs.wdl
@@ -14,3 +14,15 @@ struct SelfExclusiveSites {
 	File sites
 	Int maxAllowed
 }
+
+struct WeightSet {
+	File linear_weights # standard prs weights file
+	File? interaction_weights # interaction weights file
+	SelfExclusiveSites? interaction_self_exclusive_sites # The interaction term will only be added in no more than selfExclusiveSites.maxAllowed of the
+																												# effect alleles listed in SelfExclusizeSites.sites is observed
+}
+
+struct NamedWeightSet {
+	String condition_name
+	WeightSet weight_set
+}

--- a/ImputationPipeline/Structs.wdl
+++ b/ImputationPipeline/Structs.wdl
@@ -8,3 +8,9 @@ struct ReferencePanelContig {
 	File m3vcf
 	String contig
 }
+
+
+struct SelfExclusiveSites {
+	File sites
+	Int maxAllowed
+}

--- a/ImputationPipeline/Structs.wdl
+++ b/ImputationPipeline/Structs.wdl
@@ -11,13 +11,13 @@ struct ReferencePanelContig {
 
 
 struct SelfExclusiveSites {
-	File sites
+	File sites # must have columns id, chrom, pos
 	Int maxAllowed
 }
 
 struct WeightSet {
 	File linear_weights # standard prs weights file
-	File? interaction_weights # interaction weights file
+	File? interaction_weights # interaction weights file, must have columns id_1, id_2, chrom_1, chrom_2, pos_1, pos_2, allele_1, allele_2, weight (order not important)
 	SelfExclusiveSites? interaction_self_exclusive_sites # The interaction term will only be added in no more than selfExclusiveSites.maxAllowed of the
 																												# effect alleles listed in SelfExclusizeSites.sites is observed
 }

--- a/ImputationPipeline/Validation/ValidateScoring.wdl
+++ b/ImputationPipeline/Validation/ValidateScoring.wdl
@@ -63,7 +63,7 @@ workflow ValidateScoring {
 	#run scoring on this branch, using imputed data from this branch, or shared imputed data is we are studying only changes in scoring
 	call Scoring.ScoringImputedDataset as ScoreImputed {
 		input:
-			weights = SubsetWeightsWGS.subset_weights,
+			weight_set = object{linear_weights : SubsetWeightsWGS.subset_weights},
 			imputed_array_vcf = select_first([validationArrays, validationArraysMain]),
 			population_basename = population_basename,
 			basename = "imputed",
@@ -94,7 +94,7 @@ workflow ValidateScoring {
 	#score wgs over only sites in the imputed array which are called in every wgs sample
 	call Scoring.ScoringImputedDataset as ScoreWGS {
 		input:
-			weights = SubsetWeightsWGS.subset_weights,
+			weight_set = object{linear_weights : SubsetWeightsWGS.subset_weights},
 			imputed_array_vcf = QCSites.output_vcf,
 			population_basename = population_basename,
 			basename = "imputed",

--- a/ImputationPipeline/build_push_docker.sh
+++ b/ImputationPipeline/build_push_docker.sh
@@ -75,7 +75,11 @@ while true; do
   if [[ "${DRY}" == "true" ]]; then
     break;
   fi
-  echo "This script will build and push ${image_name}. Do you want to proceed? (y/[n])"
+  if [[ ${PUSH} == "true" ]]; then
+    echo "This script will build and push ${image_name}. Do you want to proceed? (y/[n])"
+  else
+    echo "This script will build but not push ${image_name}. Do you want to proceed? (y/[n])"
+  fi
   read yn
   [[ -z ${yn} ]] && yn=n
   case $yn in
@@ -116,4 +120,6 @@ echo "Image version tag: ${IMG_TAG}"
 
 build_opts="-t ${image_name} --build-arg UBUNTU_VERSION=${UBUNTU} ${NOCACHE}"
 execute "docker build ${docker_path} ${build_opts}"
-execute "docker push ${image_name}"
+if [[ ${PUSH} == "true" ]]; then
+  execute "docker push ${image_name}"
+fi

--- a/ImputationPipeline/imputation_interaction_python/Dockerfile
+++ b/ImputationPipeline/imputation_interaction_python/Dockerfile
@@ -2,10 +2,6 @@
 ARG UBUNTU_VERSION=20.04
 FROM ubuntu:${UBUNTU_VERSION}
 
-# the following argument is needed for pkg-config to
-# install without hanging on user input
-ARG DEBIAN_FRONTEND=noninteractive
-
 RUN apt-get update \
   && apt-get install -y python3 \
   && apt-get install -y python3-pip \

--- a/ImputationPipeline/imputation_interaction_python/Dockerfile
+++ b/ImputationPipeline/imputation_interaction_python/Dockerfile
@@ -1,0 +1,15 @@
+# default ubuntu version: 20.04
+ARG UBUNTU_VERSION=20.04
+FROM ubuntu:${UBUNTU_VERSION}
+
+# the following argument is needed for pkg-config to
+# install without hanging on user input
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y python3 \
+  && apt-get install -y python3-pip
+
+
+RUN pip install --upgrade pip
+RUN pip install cyvcf2 pandas

--- a/ImputationPipeline/imputation_interaction_python/Dockerfile
+++ b/ImputationPipeline/imputation_interaction_python/Dockerfile
@@ -8,7 +8,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
   && apt-get install -y python3 \
-  && apt-get install -y python3-pip
+  && apt-get install -y python3-pip \
+  && apt-get install -y tabix
 
 
 RUN pip install --upgrade pip


### PR DESCRIPTION
Adds interaction terms to the PRS pipeline.  For a listed interaction, each allele can only participate in the interactions once.  So, if a sample is het in one interaction allele, and hom in the other, it will have the 1x interaction weight added to the score.  If it is hom in both interaction alleles, it will have 2x interaction weight added.  And if it is het in one and doesn't contain the other, will not have the interaction weight added.  Additionally, if the two interaction alleles in the interaction are the same, then the interaction weight will be added if and only if the sample is hom in the interaction allele.

There is also a bit of a hack included here using the `SelfExclusiveSites`.  This is a set of alleles of which only a specified number are allowed to be included, or the interaction term is not added to the score.  This is a roundabout way to implement the algorithm described in the [T1D GRS2 paper ](https://pubmed.ncbi.nlm.nih.gov/30655379/) in a flexible and reusable manner.