### PR TITLE
Aggregate PRS Output

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -48,3 +48,6 @@ workflows:
   - name: CollectBenchmarkSucceeded
     subclass: WDL
     primaryDescriptorPath: /Utilities/WDLs/CollectBenchmarkSucceeded.wdl
+  - name: AggregatePRSResults
+    subclass: WDL
+    primaryDescriptor: /ImputationPipeline/AggregatePRSResults.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -48,3 +48,6 @@ workflows:
   - name: CollectBenchmarkSucceeded
     subclass: WDL
     primaryDescriptorPath: /Utilities/WDLs/CollectBenchmarkSucceeded.wdl
+  - name: AggregatePRSResults
+    subclass: WDL
+    primaryDescriptorPath: /ImputationPipeline/AggregatePRSResults.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -48,6 +48,3 @@ workflows:
   - name: CollectBenchmarkSucceeded
     subclass: WDL
     primaryDescriptorPath: /Utilities/WDLs/CollectBenchmarkSucceeded.wdl
-  - name: AggregatePRSResults
-    subclass: WDL
-    primaryDescriptor: /ImputationPipeline/AggregatePRSResults.wdl

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -164,7 +164,6 @@ task BuildHTMLReport {
     library(dplyr)
     library(stringr)
     library(kableExtra)
-    knitr::opts_chunk$set(echo = TRUE)
     batch_results <- read_tsv("~{batch_results}")
     batch_summary <- read_tsv("~{batch_summarised_results}")
     batch_summary <- batch_summary %>% rename_with(.cols = -condition, ~ str_to_title(gsub("_"," ", .x)))

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -101,12 +101,11 @@ task PlotPCA {
     library(purrr)
     library(ggplot2)
 
-    target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows) %>% mutate(cohort="~{batch_id}", size=0.5, alpha=1)
-    population_pcs <- read_tsv("~{population_pc_projections}") %>% mutate(cohort="~{population_name}", size=0.1, alpha=0.1)
+    target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows))
+    population_pcs <- read_tsv("~{population_pc_projections}"))
 
-    all_pcs <- bind_rows(target_pcs, population_pcs)
-    ggplot(all_pcs, aes(x=PC1, y=PC2)) +
-      geom_point(aes(color=cohort, size=size, alpha=alpha)) +
+    ggplot(population_pcs, aes(x=PC1, y=PC2), size=0.1, alpha=0.1, , color="~{population_name}") +
+      geom_point(data=target_pcs, color="~{batch_id}") +
       theme_bw()
 
     ggsave(filename = "~{batch_id}_PCA_plot.png", dpi=300, width = 6, height = 6)

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -197,9 +197,9 @@ task BuildHTMLReport {
 
 
     ## Control Sample
-    ```{r control, echo = FALSE, results = "asis"}
+    \`\`\`{r control, echo = FALSE, results = "asis"}
     kable(list(batch_control_results, expected_control_results) %>% reduce(bind_rows) %>% select(-batch_id) %>% select(-is_control) , digits = 2)
-    ```
+    \`\`\`
 
     ## Batch Summary
     \`\`\`{r summary table, echo = FALSE, results = "asis" }

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -77,7 +77,7 @@ task AggregateResults {
 
     write_tsv(results %>% filter(is_control == "true"), paste0(batch_id, "_control_results.tsv"))
 
-    results_pivoted <- results %>% pivot_longer(!sample_id, names_to=c("condition",".value"), names_pattern="([^_]+)_(.+)")
+    results_pivoted <- results %>% select(-batch_id) %>% select(-is_control) %>% pivot_longer(!sample_id, names_to=c("condition",".value"), names_pattern="([^_]+)_(.+)")
     results_pivoted <- results_pivoted %T>% {options(warn=-1)} %>% mutate(adjusted = as.numeric(adjusted),
                                                                           raw = as.numeric(raw),
                                                                           percentile = as.numeric(percentile)) %T>% {options(warn=0)}

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -188,7 +188,7 @@ task BuildHTMLReport {
     ```
     EOF
 
-    Rscript -e "library(rmarkdown); rmarkdown::render("~{batch_id}_report.Rmd", "html_document")
+    Rscript -e "library(rmarkdown); rmarkdown::render('~{batch_id}_report.Rmd', 'html_document')"
   >>>
 
   runtime {

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -183,7 +183,7 @@ task BuildHTMLReport {
 
     ## Individual Sample Results
     \`\`\`{r sample results , echo = FALSE, results = "asis"}
-    kable(batch_results %>% mutate(across(ends_with("risk"), ~ kableExtra::cell_spec(.x, color=ifelse(is.na(.x), "orange", ifelse(.x == "HIGH", "red", "green"))))), digits = 2)
+    kable(batch_results %>% mutate(across(ends_with("risk"), ~ kableExtra::cell_spec(.x, color=ifelse(is.na(.x), "blue", ifelse(.x=="NOT_RESULTED", "red", ifelse(.x == "HIGH", "orange", "green")))))), digits = 2)
     \`\`\`
     EOF
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -146,7 +146,7 @@ task BuildHTMLReport {
   }
 
   command <<<
-    set -xeuo pipefail
+    set -xeo pipefail
 
     cat << EOF > ~{batch_id}_report.Rmd
     ---

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -1,0 +1,119 @@
+version 1.0
+
+  workflow AggregatePRSResults {
+    input {
+      String batch_id
+      Array[File] results
+      Array[File] target_pc_projections
+      File population_pc_projections
+      String population_name = "Reference Population"
+    }
+
+    call AggregateResults {
+      input:
+        results = results,
+        batch_id = batch_id
+    }
+
+    call PlotPCA {
+      input:
+        batch_id = batch_id,
+        population_name = population_name,
+        target_pc_projections = target_pc_projections,
+        population_pc_projections = population_pc_projections
+    }
+
+    output {
+      File batch_results = AggregateResults.batch_results
+      File batch_summarised_results = AggregateResults.batch_summarised_results
+      File score_distribution = AggregateResults.score_distribution
+      File pc_polot = PlotPCA.pc_plot
+    }
+  }
+
+  task AggregateResults {
+    input {
+      Array[File] results
+      String batch_id
+    }
+
+    command <<<
+      Rscript - <<- "EOF"
+      library(dplyr)
+      library(readr)
+      library(purrr)
+      library(magrittr)
+
+      results <- c("~{sep='","' results}") %>% map(read_csv, col_types=cols(.default = 'c')) %>% reduce(bind_rows)
+      write_tsv(results, "~{batch_id}_results.tsv")
+      results_pivoted <- results_pivoted %T>% {options(warn=-1)} %>% mutate(adjusted = as.numeric(adjusted),
+                                                                            raw = as.numeric(raw),
+                                                                            percentile = as.numeric(percentile))
+                                          %T>% {options(warn=0)}
+
+      results_summarised <- results_pivoted %>% group_by(condition) %>%
+                                                summarise(across(c(adjusted,percentile), ~mean(.x, na.rm=TRUE), .names = "mean_{.col}"),
+                                                          num_samples=n(),
+                                                          num_scored = sum(!is.na(risk)),
+                                                          num_high = sum(risk=="HIGH", na.rm=TRUE),
+                                                          num_not_high = sum(risk=="NOT_HIGH", na.rm=TRUE),
+                                                          num_not_resulted = sum(risk=="NOT_RESULTED", na.rm = TRUE))
+
+      write_tsv(results_summarised, "~{batch_id}_summarised_results.tsv")
+
+      ggplot(results_pivoted, aes(x=adjusted)) +
+        geom_density(aes(color=condition), fill=NA, position = "identity") +
+        xlim(-10,10) + theme_bw() + xlab("z-score") + geom_function(fun=dnorm) +
+        ylab("density")
+      ggsave(filename = "~{batch_id}_score_distribution.png", dpi=300, width = 6, height = 6)
+    >>>
+
+    runtime {
+      docker: "rocker/tidyverse@sha256:aaace6c41a258e13da76881f0b282932377680618fcd5d121583f9455305e727"
+      disks: "local-disk 100 HDD"
+      memory: "4 GB"
+    }
+
+    output {
+      File batch_results = "~{batch_id}_results.tsv"
+      File batch_summarised_results = "~{batch_id}_summarised_results.tsv"
+      File score_distribution = "~{batch_id}_score_distribution.png"
+    }
+  }
+
+  task PlotPCA {
+    input {
+      Array[File] target_pc_projections
+      File population_pc_projections
+      String batch_id
+      String population_name
+    }
+
+    command <<<
+      Rscript - <<- "EOF"
+      library(dplyr)
+      library(readr)
+      library(purrr)
+
+      target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows) %>% mutate(cohort="~{batch_id}", size=0.5, alpha=1)
+      population_pcs <- read_tsv("~{population_pc_projections}") %>% mutate(cohort="~{population_name}", size=0.1, alpha=0.1)
+
+      all_pcs <- bind_rows(target_pcs, population_pcs)
+      ggplot(all_pcs, aes(x=PC1, y=PC2)) +
+        geom_point(aes(color=cohort, size=size, alpha=alpha)) +
+        theme_bw()
+
+      ggsave(filename = "~{batch_id}_PCA_plot.png", dpi=300, width = 6, height = 6)
+
+    >>>
+
+    runtime {
+      docker: "rocker/tidyverse@sha256:aaace6c41a258e13da76881f0b282932377680618fcd5d121583f9455305e727"
+      disks: "local-disk 100 HDD"
+      memory: "4 GB"
+    }
+
+    output {
+      File pc_plot = "~{batch_id}_PCA_plot.png"
+    }
+  }

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -104,8 +104,8 @@ task PlotPCA {
     target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows)
     population_pcs <- read_tsv("~{population_pc_projections}")
 
-    ggplot(population_pcs, aes(x=PC1, y=PC2), size=0.1, alpha=0.1, , color="~{population_name}") +
-      geom_point(data=target_pcs, color="~{batch_id}") +
+    ggplot(population_pcs, aes(x=PC1, y=PC2, color="~{population_name}"), size=0.1, alpha=0.1) +
+      geom_point(data=target_pcs, aes(color="~{batch_id}")) +
       theme_bw()
 
     ggsave(filename = "~{batch_id}_PCA_plot.png", dpi=300, width = 6, height = 6)

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -52,8 +52,7 @@ task AggregateResults {
     results_pivoted <- results %>% pivot_longer(!sample_id, names_to=c("condition",".value"), names_pattern="([^_]+)_(.+)")
     results_pivoted <- results_pivoted %T>% {options(warn=-1)} %>% mutate(adjusted = as.numeric(adjusted),
                                                                           raw = as.numeric(raw),
-                                                                          percentile = as.numeric(percentile))
-                                        %T>% {options(warn=0)}
+                                                                          percentile = as.numeric(percentile)) %T>% {options(warn=0)}
 
     results_summarised <- results_pivoted %>% group_by(condition) %>%
                                               summarise(across(c(adjusted,percentile), ~mean(.x, na.rm=TRUE), .names = "mean_{.col}"),
@@ -102,7 +101,7 @@ task PlotPCA {
     library(purrr)
     library(ggplot2)
 
-    target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows))
+    target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows)
     population_pcs <- read_tsv("~{population_pc_projections}")
 
     ggplot(population_pcs, aes(x=PC1, y=PC2), size=0.1, alpha=0.1, , color="~{population_name}") +

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -57,7 +57,7 @@ task AggregateResults {
     library(magrittr)
     library(ggplot2)
 
-    results <- c("~{sep='","' results}") %>% map(read_csv, col_types=cols(.default = 'c')) %>% reduce(bind_rows)
+    results <- c("~{sep='","' results}") %>% map(read_csv, col_types=cols(is_control='l', .default='c')) %>% reduce(bind_rows)
     
     batch_ids <- results %>% pull(batch_id) %>% unique()
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -2,22 +2,21 @@ version 1.0
 
 workflow AggregatePRSResults {
   input {
-    String batch_id
     Array[File] results
     Array[File] target_pc_projections
     File population_pc_projections
     String population_name = "Reference Population"
+    File expected_control_results
   }
 
   call AggregateResults {
     input:
-      results = results,
-      batch_id = batch_id
+      results = results
   }
 
   call PlotPCA {
     input:
-      batch_id = batch_id,
+      batch_id = AggregateResults.batch_id,
       population_name = population_name,
       target_pc_projections = target_pc_projections,
       population_pc_projections = population_pc_projections
@@ -25,17 +24,20 @@ workflow AggregatePRSResults {
 
   call BuildHTMLReport {
     input:
-      batch_results = AggregateResults.batch_results,
+      batch_id = AggregateResults.batch_id,
+      batch_all_results = AggregateResults.batch_all_results,
+      batch_control_results = AggregateResults.batch_control_results,
+      expected_control_results = expected_control_results,
       batch_summarised_results = AggregateResults.batch_summarised_results,
-      score_distribution = AggregateResults.score_distribution,
-      pc_plot = PlotPCA.pc_plot,
-      batch_id = batch_id
+      score_distribution = AggregateResults.batch_score_distribution,
+      pc_plot = PlotPCA.pc_plot
   }
 
   output {
-    File batch_results = AggregateResults.batch_results
+    File batch_all_results = AggregateResults.batch_all_results
+    File batch_control_results = AggregateResults.batch_control_results
     File batch_summarised_results = AggregateResults.batch_summarised_results
-    File score_distribution = AggregateResults.score_distribution
+    File score_distribution = AggregateResults.batch_score_distribution
     File pc_polot = PlotPCA.pc_plot
     File report = BuildHTMLReport.report
   }
@@ -44,7 +46,6 @@ workflow AggregatePRSResults {
 task AggregateResults {
   input {
     Array[File] results
-    String batch_id
   }
 
   command <<<
@@ -57,7 +58,24 @@ task AggregateResults {
     library(ggplot2)
 
     results <- c("~{sep='","' results}") %>% map(read_csv, col_types=cols(.default = 'c')) %>% reduce(bind_rows)
-    write_tsv(results, "~{batch_id}_results.tsv")
+    
+    num_batches <- lapply(results, function(row) {length(unique(row))})$batch_id
+
+    if (num_batches != 1) {
+      stop(paste0("There are ", num_batches, " batch IDs in the input tables, however, only 1 is expected."))
+    }
+
+    batch_id <- results$batch_id[1]
+
+    num_control_samples <- sum(results$is_control=="true")
+
+    if (num_batches != 1) {
+      stop(paste("There are ", num_control_samples, " control samples in the input tables, however, only 1 is expected."))
+    }
+
+    write_tsv(results, paste0(batch_id, "_all_results.tsv"))
+
+    write_tsv(results %>% filter(is_control == "true"), paste0(batch_id, "_control_results.tsv"))
 
     results_pivoted <- results %>% pivot_longer(!sample_id, names_to=c("condition",".value"), names_pattern="([^_]+)_(.+)")
     results_pivoted <- results_pivoted %T>% {options(warn=-1)} %>% mutate(adjusted = as.numeric(adjusted),
@@ -72,13 +90,15 @@ task AggregateResults {
                                                         num_not_high = sum(risk=="NOT_HIGH", na.rm=TRUE),
                                                         num_not_resulted = sum(risk=="NOT_RESULTED", na.rm = TRUE))
 
-    write_tsv(results_summarised, "~{batch_id}_summarised_results.tsv")
+    write_tsv(results_summarised, paste0(batch_id, "_summarised_results.tsv"))
 
     ggplot(results_pivoted, aes(x=adjusted)) +
       geom_density(aes(color=condition), fill=NA, position = "identity") +
       xlim(-10,10) + theme_bw() + xlab("z-score") + geom_function(fun=dnorm) +
       ylab("density")
-    ggsave(filename = "~{batch_id}_score_distribution.png", dpi=300, width = 6, height = 6)
+    ggsave(filename = paste0(batch_id, "_score_distribution.png"), dpi=300, width = 6, height = 6)
+
+    writelines(batch_id, "batch_id.txt")
 
     EOF
   >>>
@@ -90,9 +110,11 @@ task AggregateResults {
   }
 
   output {
-    File batch_results = "~{batch_id}_results.tsv"
-    File batch_summarised_results = "~{batch_id}_summarised_results.tsv"
-    File score_distribution = "~{batch_id}_score_distribution.png"
+    String batch_id = read_string("batch_id.txt")
+    File batch_all_results = glob("*_all_results.tsv")[0]
+    File batch_control_results = glob("*_control_results.tsv")[0]
+    File batch_summarised_results = glob("*_summarised_results.tsv")[0]
+    File batch_score_distribution = glob("*_score_distribution.png")[0]
   }
 }
 
@@ -114,8 +136,8 @@ task PlotPCA {
     target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows)
     population_pcs <- read_tsv("~{population_pc_projections}")
 
-    ggplot(population_pcs, aes(x=PC1, y=PC2, color="~{population_name}"), size=0.1, alpha=0.1) +
-      geom_point() +
+    ggplot(population_pcs, aes(x=PC1, y=PC2, color="~{population_name}")) +
+      geom_point(size=0.1, alpha=0.1) +
       geom_point(data=target_pcs, aes(color="~{batch_id}")) +
       theme_bw()
 
@@ -138,7 +160,9 @@ task PlotPCA {
 
 task BuildHTMLReport {
   input {
-    File batch_results
+    File batch_all_results
+    File batch_control_results
+    File expected_control_results
     File batch_summarised_results
     File score_distribution
     File pc_plot
@@ -163,10 +187,18 @@ task BuildHTMLReport {
     library(knitr)
     library(dplyr)
     library(stringr)
-    batch_results <- read_tsv("~{batch_results}")
+    batch_all_results <- read_tsv("~{batch_all_results}")
+    batch_control_results <- read_tsv("~{batch_control_results}")
+    expected_control_results <- read_tsv("~{expected_control_results}")
     batch_summary <- read_tsv("~{batch_summarised_results}")
     batch_summary <- batch_summary %>% rename_with(.cols = -condition, ~ str_to_title(gsub("_"," ", .x)))
     \`\`\`
+
+
+    ## Control Sample
+    ```{r control, echo = FALSE, results = "asis"}
+    kable(list(batch_control_results, expected_control_results) %>% reduce(bind_rows) %>% select(-batch_id) %>% select(-is_control) , digits = 2)
+    ```
 
     ## Batch Summary
     \`\`\`{r summary table, echo = FALSE, results = "asis" }
@@ -183,7 +215,7 @@ task BuildHTMLReport {
 
     ## Individual Sample Results
     \`\`\`{r sample results , echo = FALSE, results = "asis"}
-    kable(batch_results %>% mutate(across(ends_with("risk"), ~ kableExtra::cell_spec(.x, color=ifelse(is.na(.x), "blue", ifelse(.x=="NOT_RESULTED", "red", ifelse(.x == "HIGH", "orange", "green")))))), digits = 2)
+    kable(batch_all_results %>% mutate(across(ends_with("risk"), ~ kableExtra::cell_spec(.x, color=ifelse(is.na(.x), "blue", ifelse(.x=="NOT_RESULTED", "red", ifelse(.x == "HIGH", "orange", "green")))))), digits = 2)
     \`\`\`
     EOF
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -42,6 +42,7 @@ task AggregateResults {
     library(dplyr)
     library(readr)
     library(purrr)
+    library(tidyr)
     library(magrittr)
     library(ggplot2)
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -98,7 +98,7 @@ task AggregateResults {
       ylab("density")
     ggsave(filename = paste0(batch_id, "_score_distribution.png"), dpi=300, width = 6, height = 6)
 
-    writelines(batch_id, "batch_id.txt")
+    writeLines(batch_id, "batch_id.txt")
 
     EOF
   >>>

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -189,7 +189,7 @@ task BuildHTMLReport {
     library(stringr)
     library(purrr)
     library(tibble)
-    
+
     batch_all_results <- read_tsv("~{batch_all_results}")
     batch_control_results <- read_tsv("~{batch_control_results}")
     expected_control_results <- read_csv("~{expected_control_results}")
@@ -218,7 +218,7 @@ task BuildHTMLReport {
 
     ## Individual Sample Results (without control sample)
     \`\`\`{r sample results , echo = FALSE, results = "asis"}
-    kable(batch_all_results %>% filter(!is_control) %>% mutate(across(ends_with("risk"), ~ kableExtra::cell_spec(.x, color=ifelse(is.na(.x), "blue", ifelse(.x=="NOT_RESULTED", "red", ifelse(.x == "HIGH", "orange", "green")))))), digits = 2)
+    kable(batch_all_results %>% filter(!is_control) %>% select(-is_control) %>% mutate(across(ends_with("risk"), ~ kableExtra::cell_spec(.x, color=ifelse(is.na(.x), "blue", ifelse(.x=="NOT_RESULTED", "red", ifelse(.x == "HIGH", "orange", "green")))))), digits = 2)
     \`\`\`
     EOF
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -163,7 +163,6 @@ task BuildHTMLReport {
     library(knitr)
     library(dplyr)
     library(stringr)
-    library(kableExtra)
     batch_results <- read_tsv("~{batch_results}")
     batch_summary <- read_tsv("~{batch_summarised_results}")
     batch_summary <- batch_summary %>% rename_with(.cols = -condition, ~ str_to_title(gsub("_"," ", .x)))

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -146,7 +146,8 @@ task BuildHTMLReport {
   }
 
   command <<<
-
+    set -xeuo pipefail
+    
     cat << EOF > ~{batch_id}_report.Rmd
     ---
     title: "Batch ~{batch_id} PRS Summary"

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -188,6 +188,8 @@ task BuildHTMLReport {
     library(dplyr)
     library(stringr)
     library(purrr)
+    library(tibble)
+    
     batch_all_results <- read_tsv("~{batch_all_results}")
     batch_control_results <- read_tsv("~{batch_control_results}")
     expected_control_results <- read_csv("~{expected_control_results}")

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -156,7 +156,7 @@ task BuildHTMLReport {
     date: "$(date)"
     ---
 
-    ```{r setup, include=FALSE}
+    \`\`\`{r setup, include=FALSE}
     library(readr)
     library(ggplot2)
     library(knitr)
@@ -167,12 +167,12 @@ task BuildHTMLReport {
     batch_results <- read_tsv("~{batch_results}")
     batch_summary <- read_tsv("~{batch_summarised_results}")
     batch_summary <- batch_summary %>% rename_with(.cols = -condition, ~ str_to_title(gsub("_"," ", .x)))
-    ```
+    \`\`\`
 
     ## Batch Summary
-    ```{r summary table, echo = FALSE, results = "asis" }
+    \`\`\`{r summary table, echo = FALSE, results = "asis" }
     kable(batch_summary, digits = 2)
-    ```
+    \`\`\`
 
 
 
@@ -183,9 +183,9 @@ task BuildHTMLReport {
     ![](~{pc_plot})
 
     ## Individual Sample Results
-    ```{r sample results , echo = FALSE, results = "asis"}
+    \`\`\`{r sample results , echo = FALSE, results = "asis"}
     kable(batch_results %>% mutate(across(ends_with("risk"), ~ kableExtra::cell_spec(.x, color=ifelse(is.na(.x), "orange", ifelse(.x == "HIGH", "red", "green"))))), digits = 2)
-    ```
+    \`\`\`
     EOF
 
     Rscript -e "library(rmarkdown); rmarkdown::render('~{batch_id}_report.Rmd', 'html_document')"

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -102,7 +102,7 @@ task PlotPCA {
     library(ggplot2)
 
     target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows))
-    population_pcs <- read_tsv("~{population_pc_projections}"))
+    population_pcs <- read_tsv("~{population_pc_projections}")
 
     ggplot(population_pcs, aes(x=PC1, y=PC2), size=0.1, alpha=0.1, , color="~{population_name}") +
       geom_point(data=target_pcs, color="~{batch_id}") +

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -43,6 +43,7 @@ task AggregateResults {
     library(readr)
     library(purrr)
     library(magrittr)
+    library(ggplot2)
 
     results <- c("~{sep='","' results}") %>% map(read_csv, col_types=cols(.default = 'c')) %>% reduce(bind_rows)
     write_tsv(results, "~{batch_id}_results.tsv")
@@ -96,6 +97,7 @@ task PlotPCA {
     library(dplyr)
     library(readr)
     library(purrr)
+    library(ggplot2)
 
     target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows) %>% mutate(cohort="~{batch_id}", size=0.5, alpha=1)
     population_pcs <- read_tsv("~{population_pc_projections}") %>% mutate(cohort="~{population_name}", size=0.1, alpha=0.1)

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -187,6 +187,7 @@ task BuildHTMLReport {
     library(knitr)
     library(dplyr)
     library(stringr)
+    library(purrr)
     batch_all_results <- read_tsv("~{batch_all_results}")
     batch_control_results <- read_tsv("~{batch_control_results}")
     expected_control_results <- read_tsv("~{expected_control_results}")

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -190,7 +190,7 @@ task BuildHTMLReport {
     library(purrr)
     batch_all_results <- read_tsv("~{batch_all_results}")
     batch_control_results <- read_tsv("~{batch_control_results}")
-    expected_control_results <- read_tsv("~{expected_control_results}")
+    expected_control_results <- read_csv("~{expected_control_results}")
     batch_summary <- read_tsv("~{batch_summarised_results}")
     batch_summary <- batch_summary %>% rename_with(.cols = -condition, ~ str_to_title(gsub("_"," ", .x)))
     \`\`\`

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -198,7 +198,7 @@ task BuildHTMLReport {
 
     ## Control Sample
     \`\`\`{r control, echo = FALSE, results = "asis"}
-    kable(list(batch_control_results, expected_control_results) %>% reduce(bind_rows) %>% select(-batch_id, -is_control) , digits = 2)
+    kable(list(batch_control_results, expected_control_results) %>% reduce(bind_rows) %>% select(-batch_id, -is_control) %>% add_column(Sample=c('Batch control', 'Expected control'), .before='sample_id'), digits = 2)
     \`\`\`
 
     ## Batch Summary

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -64,6 +64,7 @@ task AggregateResults {
     if (length(batch_ids) != 1) {
       stop(paste0("There are ", length(batch_ids), " batch IDs in the input tables, however, only 1 is expected."))
     }
+    # If there is only one batch_id, then batch_ids will have length 1 and can be treated as a single value from here on
 
     num_control_samples <- results %>% filter(is_control) %>% count()
 
@@ -75,7 +76,7 @@ task AggregateResults {
 
     write_tsv(results %>% filter(is_control), paste0(batch_ids, "_control_results.tsv"))
 
-    results_pivoted <- results %>% select(-batch_ids, -is_control) %>% pivot_longer(!sample_id, names_to=c("condition",".value"), names_pattern="([^_]+)_(.+)")
+    results_pivoted <- results %>% select(-batch_id, -is_control) %>% pivot_longer(!sample_id, names_to=c("condition",".value"), names_pattern="([^_]+)_(.+)")
     results_pivoted <- results_pivoted %T>% {options(warn=-1)} %>% mutate(adjusted = as.numeric(adjusted),
                                                                           raw = as.numeric(raw),
                                                                           percentile = as.numeric(percentile)) %T>% {options(warn=0)}

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -1,119 +1,119 @@
 version 1.0
 
-  workflow AggregatePRSResults {
-    input {
-      String batch_id
-      Array[File] results
-      Array[File] target_pc_projections
-      File population_pc_projections
-      String population_name = "Reference Population"
-    }
-
-    call AggregateResults {
-      input:
-        results = results,
-        batch_id = batch_id
-    }
-
-    call PlotPCA {
-      input:
-        batch_id = batch_id,
-        population_name = population_name,
-        target_pc_projections = target_pc_projections,
-        population_pc_projections = population_pc_projections
-    }
-
-    output {
-      File batch_results = AggregateResults.batch_results
-      File batch_summarised_results = AggregateResults.batch_summarised_results
-      File score_distribution = AggregateResults.score_distribution
-      File pc_polot = PlotPCA.pc_plot
-    }
+workflow AggregatePRSResults {
+  input {
+    String batch_id
+    Array[File] results
+    Array[File] target_pc_projections
+    File population_pc_projections
+    String population_name = "Reference Population"
   }
 
-  task AggregateResults {
-    input {
-      Array[File] results
-      String batch_id
-    }
-
-    command <<<
-      Rscript - <<- "EOF"
-      library(dplyr)
-      library(readr)
-      library(purrr)
-      library(magrittr)
-
-      results <- c("~{sep='","' results}") %>% map(read_csv, col_types=cols(.default = 'c')) %>% reduce(bind_rows)
-      write_tsv(results, "~{batch_id}_results.tsv")
-      results_pivoted <- results_pivoted %T>% {options(warn=-1)} %>% mutate(adjusted = as.numeric(adjusted),
-                                                                            raw = as.numeric(raw),
-                                                                            percentile = as.numeric(percentile))
-                                          %T>% {options(warn=0)}
-
-      results_summarised <- results_pivoted %>% group_by(condition) %>%
-                                                summarise(across(c(adjusted,percentile), ~mean(.x, na.rm=TRUE), .names = "mean_{.col}"),
-                                                          num_samples=n(),
-                                                          num_scored = sum(!is.na(risk)),
-                                                          num_high = sum(risk=="HIGH", na.rm=TRUE),
-                                                          num_not_high = sum(risk=="NOT_HIGH", na.rm=TRUE),
-                                                          num_not_resulted = sum(risk=="NOT_RESULTED", na.rm = TRUE))
-
-      write_tsv(results_summarised, "~{batch_id}_summarised_results.tsv")
-
-      ggplot(results_pivoted, aes(x=adjusted)) +
-        geom_density(aes(color=condition), fill=NA, position = "identity") +
-        xlim(-10,10) + theme_bw() + xlab("z-score") + geom_function(fun=dnorm) +
-        ylab("density")
-      ggsave(filename = "~{batch_id}_score_distribution.png", dpi=300, width = 6, height = 6)
-    >>>
-
-    runtime {
-      docker: "rocker/tidyverse@sha256:aaace6c41a258e13da76881f0b282932377680618fcd5d121583f9455305e727"
-      disks: "local-disk 100 HDD"
-      memory: "4 GB"
-    }
-
-    output {
-      File batch_results = "~{batch_id}_results.tsv"
-      File batch_summarised_results = "~{batch_id}_summarised_results.tsv"
-      File score_distribution = "~{batch_id}_score_distribution.png"
-    }
+  call AggregateResults {
+    input:
+      results = results,
+      batch_id = batch_id
   }
 
-  task PlotPCA {
-    input {
-      Array[File] target_pc_projections
-      File population_pc_projections
-      String batch_id
-      String population_name
-    }
-
-    command <<<
-      Rscript - <<- "EOF"
-      library(dplyr)
-      library(readr)
-      library(purrr)
-
-      target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows) %>% mutate(cohort="~{batch_id}", size=0.5, alpha=1)
-      population_pcs <- read_tsv("~{population_pc_projections}") %>% mutate(cohort="~{population_name}", size=0.1, alpha=0.1)
-
-      all_pcs <- bind_rows(target_pcs, population_pcs)
-      ggplot(all_pcs, aes(x=PC1, y=PC2)) +
-        geom_point(aes(color=cohort, size=size, alpha=alpha)) +
-        theme_bw()
-
-      ggsave(filename = "~{batch_id}_PCA_plot.png", dpi=300, width = 6, height = 6)
-
-    >>>
-
-    runtime {
-      docker: "rocker/tidyverse@sha256:aaace6c41a258e13da76881f0b282932377680618fcd5d121583f9455305e727"
-      disks: "local-disk 100 HDD"
-      memory: "4 GB"
-    }
-
-    output {
-      File pc_plot = "~{batch_id}_PCA_plot.png"
-    }
+  call PlotPCA {
+    input:
+      batch_id = batch_id,
+      population_name = population_name,
+      target_pc_projections = target_pc_projections,
+      population_pc_projections = population_pc_projections
   }
+
+  output {
+    File batch_results = AggregateResults.batch_results
+    File batch_summarised_results = AggregateResults.batch_summarised_results
+    File score_distribution = AggregateResults.score_distribution
+    File pc_polot = PlotPCA.pc_plot
+  }
+}
+
+task AggregateResults {
+  input {
+    Array[File] results
+    String batch_id
+  }
+
+  command <<<
+    Rscript - <<- "EOF"
+    library(dplyr)
+    library(readr)
+    library(purrr)
+    library(magrittr)
+
+    results <- c("~{sep='","' results}") %>% map(read_csv, col_types=cols(.default = 'c')) %>% reduce(bind_rows)
+    write_tsv(results, "~{batch_id}_results.tsv")
+    results_pivoted <- results_pivoted %T>% {options(warn=-1)} %>% mutate(adjusted = as.numeric(adjusted),
+                                                                          raw = as.numeric(raw),
+                                                                          percentile = as.numeric(percentile))
+                                        %T>% {options(warn=0)}
+
+    results_summarised <- results_pivoted %>% group_by(condition) %>%
+                                              summarise(across(c(adjusted,percentile), ~mean(.x, na.rm=TRUE), .names = "mean_{.col}"),
+                                                        num_samples=n(),
+                                                        num_scored = sum(!is.na(risk)),
+                                                        num_high = sum(risk=="HIGH", na.rm=TRUE),
+                                                        num_not_high = sum(risk=="NOT_HIGH", na.rm=TRUE),
+                                                        num_not_resulted = sum(risk=="NOT_RESULTED", na.rm = TRUE))
+
+    write_tsv(results_summarised, "~{batch_id}_summarised_results.tsv")
+
+    ggplot(results_pivoted, aes(x=adjusted)) +
+      geom_density(aes(color=condition), fill=NA, position = "identity") +
+      xlim(-10,10) + theme_bw() + xlab("z-score") + geom_function(fun=dnorm) +
+      ylab("density")
+    ggsave(filename = "~{batch_id}_score_distribution.png", dpi=300, width = 6, height = 6)
+  >>>
+
+  runtime {
+    docker: "rocker/tidyverse@sha256:aaace6c41a258e13da76881f0b282932377680618fcd5d121583f9455305e727"
+    disks: "local-disk 100 HDD"
+    memory: "4 GB"
+  }
+
+  output {
+    File batch_results = "~{batch_id}_results.tsv"
+    File batch_summarised_results = "~{batch_id}_summarised_results.tsv"
+    File score_distribution = "~{batch_id}_score_distribution.png"
+  }
+}
+
+task PlotPCA {
+  input {
+    Array[File] target_pc_projections
+    File population_pc_projections
+    String batch_id
+    String population_name
+  }
+
+  command <<<
+    Rscript - <<- "EOF"
+    library(dplyr)
+    library(readr)
+    library(purrr)
+
+    target_pcs <- c("~{sep='","' target_pc_projections}") %>% map(read_tsv) %>% reduce(bind_rows) %>% mutate(cohort="~{batch_id}", size=0.5, alpha=1)
+    population_pcs <- read_tsv("~{population_pc_projections}") %>% mutate(cohort="~{population_name}", size=0.1, alpha=0.1)
+
+    all_pcs <- bind_rows(target_pcs, population_pcs)
+    ggplot(all_pcs, aes(x=PC1, y=PC2)) +
+      geom_point(aes(color=cohort, size=size, alpha=alpha)) +
+      theme_bw()
+
+    ggsave(filename = "~{batch_id}_PCA_plot.png", dpi=300, width = 6, height = 6)
+
+  >>>
+
+  runtime {
+    docker: "rocker/tidyverse@sha256:aaace6c41a258e13da76881f0b282932377680618fcd5d121583f9455305e727"
+    disks: "local-disk 100 HDD"
+    memory: "4 GB"
+  }
+
+  output {
+    File pc_plot = "~{batch_id}_PCA_plot.png"
+  }
+}

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -38,7 +38,7 @@ workflow AggregatePRSResults {
     File batch_control_results = AggregateResults.batch_control_results
     File batch_summarised_results = AggregateResults.batch_summarised_results
     File score_distribution = AggregateResults.batch_score_distribution
-    File pc_polot = PlotPCA.pc_plot
+    File pc_plot = PlotPCA.pc_plot
     File report = BuildHTMLReport.report
   }
 }

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -47,6 +47,8 @@ task AggregateResults {
 
     results <- c("~{sep='","' results}") %>% map(read_csv, col_types=cols(.default = 'c')) %>% reduce(bind_rows)
     write_tsv(results, "~{batch_id}_results.tsv")
+
+    results_pivoted <- results %>% pivot_longer(!sample_id, names_to=c("condition",".value"), names_pattern="([^_]+)_(.+)")
     results_pivoted <- results_pivoted %T>% {options(warn=-1)} %>% mutate(adjusted = as.numeric(adjusted),
                                                                           raw = as.numeric(raw),
                                                                           percentile = as.numeric(percentile))

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -66,6 +66,8 @@ task AggregateResults {
       xlim(-10,10) + theme_bw() + xlab("z-score") + geom_function(fun=dnorm) +
       ylab("density")
     ggsave(filename = "~{batch_id}_score_distribution.png", dpi=300, width = 6, height = 6)
+
+    EOF
   >>>
 
   runtime {
@@ -104,6 +106,8 @@ task PlotPCA {
       theme_bw()
 
     ggsave(filename = "~{batch_id}_PCA_plot.png", dpi=300, width = 6, height = 6)
+
+    EOF
 
   >>>
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -105,6 +105,7 @@ task PlotPCA {
     population_pcs <- read_tsv("~{population_pc_projections}")
 
     ggplot(population_pcs, aes(x=PC1, y=PC2, color="~{population_name}"), size=0.1, alpha=0.1) +
+      geom_point() +
       geom_point(data=target_pcs, aes(color="~{batch_id}")) +
       theme_bw()
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -147,7 +147,7 @@ task BuildHTMLReport {
 
   command <<<
     set -xeuo pipefail
-    
+
     cat << EOF > ~{batch_id}_report.Rmd
     ---
     title: "Batch ~{batch_id} PRS Summary"
@@ -193,7 +193,7 @@ task BuildHTMLReport {
   >>>
 
   runtime {
-    docker: "rocker/tidyverse@sha256:aaace6c41a258e13da76881f0b282932377680618fcd5d121583f9455305e727"
+    docker: "us.gcr.io/broad-dsde-methods/tidyverse_kableextra_docker@sha256:e00dd57a1c446e9c07429929893a8399c4a299f0b4fd182245bf45e77c6ab8bd"
     disks: "local-disk 100 HDD"
     memory: "4 GB"
   }

--- a/ImputationPipeline/PRSWrapper.wdl
+++ b/ImputationPipeline/PRSWrapper.wdl
@@ -83,6 +83,7 @@ workflow PRSWrapper {
 
   output {
     File results = JoinResults.results
+    File pcs = select_first(ScoringImputedDataset.pc_projection)
   }
 }
 

--- a/ImputationPipeline/PRSWrapper.wdl
+++ b/ImputationPipeline/PRSWrapper.wdl
@@ -166,6 +166,7 @@ task JoinResults {
     library(dplyr)
     library(readr)
     library(purrr)
+    library(tibble)
 
     results <- c("~{sep = '","' results_in}") %>% map(read_csv) %>% reduce(inner_join) %>% add_column(batch_id=~{batch_id}, .after="sample_id") %>% add_column(batch_id=~{is_control}, .after="batch_id")
     write_csv(results, "results.csv")

--- a/ImputationPipeline/PRSWrapper.wdl
+++ b/ImputationPipeline/PRSWrapper.wdl
@@ -168,7 +168,7 @@ task JoinResults {
     library(purrr)
     library(tibble)
 
-    results <- c("~{sep = '","' results_in}") %>% map(read_csv) %>% reduce(inner_join) %>% add_column(batch_id=~{batch_id}, .after="sample_id") %>% add_column(batch_id=~{is_control}, .after="batch_id")
+    results <- c("~{sep = '","' results_in}") %>% map(read_csv) %>% reduce(inner_join) %>% add_column(batch_id="~{batch_id}", .after="sample_id") %>% add_column(is_control="~{is_control}", .after="batch_id")
     write_csv(results, "results.csv")
     EOF
   >>>

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -161,6 +161,7 @@ workflow ScoringImputedDataset {
 	File? adjusted_population_scores = AdjustScores.adjusted_population_scores
 	File? adjusted_array_scores = AdjustScores.adjusted_array_scores
 	Boolean? fit_converged = AdjustScores.fit_converged
+	File? pc_projection = ProjectArray.projections
 	File raw_scores = ScoreImputedArray.score
   }
 }

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -145,7 +145,7 @@ workflow ScoringImputedDataset {
 			input:
 			population_pcs = select_first([PerformPCA.pcs, population_pcs]),
 			population_scores = ScorePopulation.score,
-			array_pcs = select_first([ProjectArray.projections]),
+			array_pcs = ProjectArray.projections,
 			array_scores = ScoreImputedArray.score
 		  }
 		if (!CheckPopulationIdsValid.files_are_valid) {

--- a/ImputationPipeline/tidyverse_kableextra_docker/Dockerfile
+++ b/ImputationPipeline/tidyverse_kableextra_docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM rocker/tidyverse@sha256:aaace6c41a258e13da76881f0b282932377680618fcd5d121583f9455305e727
+
+RUN R -e 'install.packages("kableExtra")'

--- a/ImputationPipeline/tidyverse_kableextra_docker/build_push_r_kableextra_docker.sh
+++ b/ImputationPipeline/tidyverse_kableextra_docker/build_push_r_kableextra_docker.sh
@@ -1,0 +1,17 @@
+# Build docker image from Dockerfile in this directory
+# This is to help keep track of versions, etc.
+# Wraps around ImputationPipeline/build_push_docker.sh.
+
+dockerfile_directory=tidyverse_kableextra_docker
+image_version=v1.0.0 # as of Jan 13 2022
+
+wd=$(pwd)
+cd "$(dirname $0)" || exit
+
+../build_push_docker.sh \
+  --directory ${dockerfile_directory} \
+  --image-version-tag ${image_version} \
+#  --dry-run
+
+
+cd "${wd}" || exit


### PR DESCRIPTION
- PRSWrapper.wdl
  - Added columns `batch_id` and `is_control` to results.csv
- New file: AggregatePRSResults
  - Aggregate multiple results CSV files into summarized tables
    - Check that all `batch_id`s are the same
    - Check that there is exactly one control sample within every batch
    - Extract control sample
    - Extract results in two shapes: `all_results` and `summarized_results`
    - Extract score distribution
  - Create population PCA plot
  - Build HTML report
    - Compare control sample to expected control result
    - Batch summary
    - Score distribution
    - Population PCA
    - Individual results
- Added to Dockstore.yml
- Fixed bug in ScoringPart.wdl