### PR TITLE
Improved formatting of samples table in prs aggregation report

### DIFF
--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -288,7 +288,7 @@ task BuildHTMLReport {
     all_cols = batch_results_table %>% colnames()
     risk_cols = which(endsWith(all_cols, "risk"))
     raw_cols = which(endsWith(all_cols, "raw"))
-    adjusted_cols = which(endsWith(all_cols, "adjusted"))
+    adjusted_cols = which(endsWith(all_cols, "adj"))
     percentile_cols = which(endsWith(all_cols, "%"))
     reason_not_resulted_cols = which(endsWith(all_cols, "reason_not_resulted"))
     numeric_cols = batch_results_table %>% select(where(is.numeric)) %>% colnames()

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -273,7 +273,7 @@ task BuildHTMLReport {
     ## Individual Sample Results (without control sample)
     \`\`\`{r sample results , echo = FALSE, results = "asis", warning = FALSE}
     batch_results_table <- batch_pivoted_results %>% filter(!is_control_sample) %>% select(!is_control_sample) %>%
-      mutate(across(!c(sample_id, lab_batch, reason_not_resulted, condition), ~kableExtra::cell_spec(gsub("_", " ", ifelse(is.na(as.numeric(.x)), ifelse(is.na(.x), 'SCORE NOT REQUESTED', .x), round(as.numeric(.x), 2))), color=ifelse(is.na(risk), "blue", ifelse(risk=="NOT_RESULTED", "red", ifelse(risk == "HIGH", "orange", "green")))))) %>% # round numbers, color all by risk
+      mutate(across(!c(sample_id, lab_batch, reason_not_resulted, condition), ~kableExtra::cell_spec(gsub("_", " ", ifelse(is.na(as.numeric(.x)), ifelse(is.na(.x), 'SCORE NOT REQUESTED', .x), round(as.numeric(.x), 2))), color=ifelse(is.na(risk), "lightgrey", ifelse(risk=="NOT_RESULTED", "red", ifelse(risk == "HIGH", "orange", "green")))))) %>% # round numbers, color all by risk
       mutate(reason_not_resulted = ifelse(is.na(reason_not_resulted), reason_not_resulted, kableExtra::cell_spec(reason_not_resulted, color="red"))) %>% # reason not resulted always red if exists
       pivot_wider(id_cols = c(sample_id, lab_batch), names_from = condition, names_glue = "{condition}_{.value}", values_from = c(raw, adjusted, percentile, risk, reason_not_resulted)) # pivot to wide format
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -275,8 +275,12 @@ task BuildHTMLReport {
     \`\`\`{r sample results , echo = FALSE, results = "asis"}
     batch_results_table <- batch_all_results %>%
     filter(!is_control_sample) %>% select(!is_control_sample) %>%
+    mutate(across(ends_with("raw") | ends_with("adjusted") | ends_with("percentile"), ~ kableExtra::cell_spec(gsub("_", " ", ifelse(is.na(as.numeric(.x)), ifelse(is.na(.x), 'SCORE NOT REQUESTED', .x), round(as.numeric(.x), 2))), color = ifelse(is.na(.x), "blue", ifelse(.x == "NOT_RESULTED", "red", "black"))))) %>%
+    mutate(across(ends_with("risk"), ~ kableExtra::cell_spec(gsub("_", " ", ifelse(is.na(.x), 'SCORE NOT REQUESTED', .x)), color=ifelse(is.na(.x), "blue", ifelse(.x=="NOT_RESULTED", "red", ifelse(.x == "HIGH", "orange", "green")))))) %>%
+    mutate(across(ends_with("reason_not_resulted"), ~ifelse(is.na(.x), .x, kableExtra::cell_spec(.x, color = "red")))) %>%
     rename_with(.cols = ends_with("percentile"), .fn = ~gsub("_percentile", " %", .x,fixed=TRUE)) %>%
-    mutate(across(ends_with("risk"), ~ kableExtra::cell_spec(.x, color=ifelse(is.na(.x), "blue", ifelse(.x=="NOT_RESULTED", "red", ifelse(.x == "HIGH", "orange", "green"))))))
+    rename_with(.cols = ends_with("adjusted"), .fn = ~gsub("_adjusted", "_adj", .x,fixed=TRUE))
+    
     all_cols = batch_results_table %>% colnames()
     risk_cols = which(endsWith(all_cols, "risk"))
     raw_cols = which(endsWith(all_cols, "raw"))

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -271,7 +271,7 @@ task BuildHTMLReport {
     \`\`\`
 
     ## Individual Sample Results (without control sample)
-    \`\`\`{r sample results , echo = FALSE, results = "asis"}
+    \`\`\`{r sample results , echo = FALSE, results = "asis", warning = FALSE}
     batch_results_table <- batch_pivoted_results %>% filter(!is_control_sample) %>% select(!is_control_sample) %>%
       mutate(across(!c(sample_id, lab_batch, reason_not_resulted, condition), ~kableExtra::cell_spec(gsub("_", " ", ifelse(is.na(as.numeric(.x)), ifelse(is.na(.x), 'SCORE NOT REQUESTED', .x), round(as.numeric(.x), 2))), color=ifelse(is.na(risk), "blue", ifelse(risk=="NOT_RESULTED", "red", ifelse(risk == "HIGH", "orange", "green")))))) %>% # round numbers, color all by risk
       mutate(reason_not_resulted = ifelse(is.na(reason_not_resulted), reason_not_resulted, kableExtra::cell_spec(reason_not_resulted, color="red"))) %>% # reason not resulted always red if exists
@@ -330,8 +330,7 @@ task BuildHTMLReport {
                           )
                   )
     )  %>%
-    formatStyle(columns = c("sample_id", "lab_batch"), fontWeight = 'bold') %>%
-    formatRound(columns = numeric_cols)
+    formatStyle(columns = c("sample_id", "lab_batch"), fontWeight = 'bold')
     \`\`\`
 
     ## Missing sites

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -211,6 +211,8 @@ task BuildHTMLReport {
     library(tibble)
     library(plotly)
     library(DT)
+    library(stringi)
+    library(tidyr)
 
     batch_control_results <- read_tsv("~{batch_control_results}", col_types = cols(.default = 'n'))
     expected_control_results <- read_csv("~{expected_control_results}", col_types = cols(.default = 'n'))


### PR DESCRIPTION
This PR makes some improvements and fixes some bugs in the formatting of the samples table in the PRS aggregation report.  Specifically:

1. All condition related cells ({condition}_raw, {condition}_adj, etc) are now colored according the the risk status for that condition.
2. A bug is fixed so that all numerics are correctly rounded
3. NA (for scores that were not calculated) is replaced with "SCORE NOT REQUESTED", and colored light gray.
4. "_" is removed in string cells (so "NOT_RESULTED" become "NOT RESULTED" )
5. {condition}_adjusted is changed to {condition}_adj, to better fit more columns without needing to use the slider.

Note all of the changes are to display only.  The underlying data is not changed.