### PR TITLE
SimpleBenchmark -- a new WDL for benchmarking VCFs

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -15,6 +15,9 @@ workflows:
   - name: BenchmarkVCFs
     subclass: WDL
     primaryDescriptorPath: /BenchmarkVCFs/BenchmarkVCFs.wdl
+  - name: SimpleBenchmark
+    subclass: WDL
+    primaryDescriptorPath: /BenchmarkVCFs/SimpleBenchmark.wdl
   - name: ValidateImputation
     subclass: WDL
     primaryDescriptorPath: /ImputationPipeline/Validation/ValidateImputation.wdl

--- a/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-MS.ipynb
+++ b/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-MS.ipynb
@@ -1,0 +1,695 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e94dadd5-aeb7-4be0-a1c7-15093f206c07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.express as px\n",
+    "\n",
+    "import quickboard.base as qbb\n",
+    "import quickboard.plugins as plg\n",
+    "from quickboard.app import start_app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb21bf04-431f-47c9-b81c-dd9c839318dc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ca0ff2b-ad4e-49df-8fed-cea58be90845",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da870f32-9825-4627-81d8-5186411f5a90",
+   "metadata": {},
+   "source": [
+    "## User Inputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4988e683-1ff0-4e3d-b8bf-471f2d6b6389",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Users must specify column names for quantities to use in making some plots below. See the docs for details.\n",
+    "# Toggle optional values here to affect behavior of generated Dashboard.\n",
+    "\n",
+    "# Fill with column name (or list of column names) to plot x-axis vs benchmark stats, e.g. 'Mean_Coverage' \n",
+    "# Users must edit data files to provide the data\n",
+    "stat_correlator = None\n",
+    "\n",
+    "# Display only usual 6 variant types as options in variant type selection; Toggle to False to include other categories like MNP, MA, etc.\n",
+    "simple_variants_only = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35f1c553-5324-4838-9f14-1da97e6616e8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "734389b3-2b20-4539-ab80-5a23e83ca67c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10006794-0851-4be3-931f-0d56b4dc7f26",
+   "metadata": {},
+   "source": [
+    "## Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "944ff6b4-e154-484c-9a0b-7487a43559ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These file paths must point to the corresponding output files from the WDL, either saved locally or bucket links\n",
+    "# In this multi-sample version, users should edit the files below prior to add columns based on desired functionality. See the docs for details.\n",
+    "\n",
+    "idd_df = pd.read_csv('Full_IDD.tsv', sep='\\t')\n",
+    "roc_df = pd.read_csv('Full_ROC.tsv', sep='\\t')\n",
+    "st_df = pd.read_csv('Full_ST.tsv', sep='\\t')\n",
+    "summary_df = pd.read_csv('SimpleSummary.tsv', sep='\\t')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec5428d5-7e67-48ad-9a0b-aa339a59ae25",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5276c52c-c4dd-46ea-8c97-a1a94a0d8ed6",
+   "metadata": {},
+   "source": [
+    "### Fill Null Stratifier Entries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edfffd21-70aa-4edd-8e98-07f8dd998bdd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for df in [idd_df, roc_df, st_df, summary_df]:\n",
+    "    strat_values = df['Stratifier'].unique()\n",
+    "    if 'Whole Genome' not in strat_values:\n",
+    "        df['Stratifier'] = df['Stratifier'].fillna('Whole Genome')\n",
+    "    elif 'Whole Genome (default)' in strat_values:\n",
+    "        raise ValueError(\"Error: Rename your stratifier labels to not include either 'Whole Genome' or 'Whole Genome (default)'\")\n",
+    "    else:\n",
+    "        df['Stratifier'] = df['Stratifier'].fillna('Whole Genome (default)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1da12418-39a8-491b-bafc-4f5785a7f508",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16d6f224-3586-4701-989e-56542f618754",
+   "metadata": {},
+   "source": [
+    "### Fill Experiment Column if not Provided"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccaf72e9-10fe-473d-a5c8-76fa872e6126",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for df in [idd_df, roc_df, st_df, summary_df]:\n",
+    "    if 'Experiment' not in df.columns:\n",
+    "        df['Experiment'] = 'No_ExpGroups_Provided'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c4d3157-51c3-460e-a9a9-795adcded627",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d2c2fbd-8260-4709-ae7f-bd4addc6f071",
+   "metadata": {},
+   "source": [
+    "## Plugin Utilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5740e865-227a-4fb0-b009-df2a630d94e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Constants\n",
+    "simple_variants = ['SNP', 'HetSNP', 'HomVarSNP', 'INDEL', 'HetINDEL', 'HomVarINDEL']\n",
+    "\n",
+    "def make_strat_selector(df):\n",
+    "    return plg.DataFilterRadioButtons(\n",
+    "        header=\"Interval List\",\n",
+    "        data_col='Stratifier',\n",
+    "        data_values=list(df['Stratifier'].unique())\n",
+    "    )\n",
+    "\n",
+    "def make_type_selector(df):\n",
+    "    if simple_variants_only:\n",
+    "        variant_values = [x for x in simple_variants if x in df['Type'].unique()]\n",
+    "    else:\n",
+    "        variant_values = list(df['Type'].unique())\n",
+    "    return plg.DataFilterRadioButtons(\n",
+    "        header=\"Variant Type\",\n",
+    "        data_col='Type',\n",
+    "        data_values=variant_values\n",
+    "    )\n",
+    "\n",
+    "def make_sample_selector(df):\n",
+    "    return plg.DataFilterChecklist(\n",
+    "        header=\"Callset Sample\",\n",
+    "        data_col='Call_Name',\n",
+    "        data_values=list(df['Call_Name'].unique())\n",
+    "    )\n",
+    "\n",
+    "def make_experiment_selector(df):\n",
+    "    return plg.DataFilterChecklist(\n",
+    "        header=\"Experimental Groups\",\n",
+    "        data_col='Experiment',\n",
+    "        data_values=list(df['Experiment'].unique()),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30f97b66-88a2-4809-81e9-ec9ec39ea4cd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "426286da-b587-41c9-a003-d1e9e354c9cf",
+   "metadata": {},
+   "source": [
+    "## Summary Tab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a767c924-199c-44f4-b8b2-84ac10b7c4ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_prec_recall_plot(df, marginal):\n",
+    "    strat = df['Stratifier'].iloc[0]\n",
+    "    type_ = df['Type'].iloc[0]\n",
+    "    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'\n",
+    "    marginal = marginal.lower() if marginal != 'None' else None\n",
+    "    return px.scatter(df, x='Recall', y='Precision', color=color, marginal_x=marginal, marginal_y=marginal,\n",
+    "                      hover_data=['Call_Name', 'Total_Base', 'Total_Call'], title=f'Precision vs Recall Plot over {strat} for {type_}')\n",
+    "\n",
+    "\n",
+    "def make_stat_corr_plot(df, stat_corr, stat):\n",
+    "    strat = df['Stratifier'].iloc[0]\n",
+    "    type_ = df['Type'].iloc[0]\n",
+    "    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'\n",
+    "    # color = 'Call_Name'\n",
+    "    return px.scatter(df, x=stat_corr, y=stat, color=color, hover_data=['Call_Name', 'TP_Base', 'TP_Call', 'FP', 'FN'],\n",
+    "                      title=f'Plot of {stat} by {stat_corr} over {strat} for {type_}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9519b819-bf4a-4e98-963f-18d09987cb5b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary_sidebar_plugins = [\n",
+    "    make_strat_selector(summary_df),\n",
+    "    make_type_selector(summary_df),\n",
+    "    make_experiment_selector(summary_df)\n",
+    "]\n",
+    "\n",
+    "\n",
+    "# Prec vs Recall plot \n",
+    "\n",
+    "prec_recall_plot = qbb.PlotPanel(\n",
+    "    header=\"Precision vs Recall Plot\",\n",
+    "    plotter=make_prec_recall_plot,\n",
+    "    plot_inputs={\n",
+    "        'marginal': 'Box'\n",
+    "    },\n",
+    "    data_source=summary_df,\n",
+    "    plugins=[\n",
+    "        plg.PlotInputRadioButtons(\n",
+    "            header='Marginal Plot Type',\n",
+    "            plot_input='marginal',\n",
+    "            data_values=['None', 'Box', 'Violin', 'Histogram', 'Rug']\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Stat correlator plot\n",
+    "\n",
+    "stat_corr_plugins = [\n",
+    "    plg.PlotInputRadioButtons(\n",
+    "        header='Statistic to Plot',\n",
+    "        plot_input='stat',\n",
+    "        data_values=['F1_Score', 'Precision', 'Recall']\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "if stat_correlator is not None:\n",
+    "    if isinstance(stat_correlator, str):\n",
+    "        correlators = [stat_correlator]\n",
+    "    else:\n",
+    "        try: \n",
+    "            assert isinstance(stat_correlator, list)\n",
+    "            correlators = stat_correlator\n",
+    "            stat_corr_plugins += [\n",
+    "                plg.PlotInputRadioButtons(\n",
+    "                    header='Stat Correlator to Plot',\n",
+    "                    plot_input='stat_corr',\n",
+    "                    data_values=correlators\n",
+    "                )\n",
+    "            ]\n",
+    "        except AssertionError:\n",
+    "            print('stat_correlator must be a string or list of strings!')\n",
+    "\n",
+    "    stat_corr_plot = qbb.PlotPanel(\n",
+    "        header=\"Stat Correlation Plot\",\n",
+    "        plotter=make_stat_corr_plot,\n",
+    "        plot_inputs={\n",
+    "            'stat_corr': correlators[0],\n",
+    "            'stat': 'F1_Score'\n",
+    "        },\n",
+    "        data_source=summary_df,\n",
+    "        plugins=stat_corr_plugins\n",
+    "    )\n",
+    "\n",
+    "bench_stat_cg = qbb.ContentGrid(\n",
+    "    header='Benchmarking Stat Scatter Plots',\n",
+    "    content_list=[prec_recall_plot] + ([stat_corr_plot] if stat_correlator is not None else [])\n",
+    ")\n",
+    "\n",
+    "\n",
+    "summary_tab = qbb.BaseTab(\n",
+    "    tab_label=\"Simple Summary\",\n",
+    "    tab_header=\"Plot for Simple Summary Stats\",\n",
+    "    content_list=[\n",
+    "        bench_stat_cg\n",
+    "    ],\n",
+    "    sidebar_plugins=summary_sidebar_plugins\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a394956-ff05-46d5-b911-b45050571dbb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eba0625-3c2a-4a06-a387-350f3c5a47ab",
+   "metadata": {},
+   "source": [
+    "## SNP Tab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54ec0cf5-c2f1-480a-af50-d514bc5893a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st_df['Ref_Nucleotide'] = st_df['Substitution'].apply(lambda x: x.split('>')[0])\n",
+    "st_df['Var_Nucleotide'] = st_df['Substitution'].apply(lambda x: x.split('>')[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "274b6218-1df8-46af-a9ea-6d63ddd0e47f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_snp_substitution_plot(df, stat):\n",
+    "    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'\n",
+    "    strat = df['Stratifier'].iloc[0]\n",
+    "    type_ = df['Type'].iloc[0]\n",
+    "    df_means = df.groupby(['Experiment', 'Type', 'Substitution_Type', 'Ref_Nucleotide', 'Var_Nucleotide'])[['TP_Base', 'TP_Call', \n",
+    "                                                                               'FP', 'FN', 'F1_Score', 'Precision', 'Recall']].mean().reset_index()\n",
+    "    df_conf = df.groupby(['Experiment', 'Type', 'Substitution_Type', 'Ref_Nucleotide', 'Var_Nucleotide'])[[\n",
+    "        'TP_Base', 'TP_Call', 'FP', 'FN', 'F1_Score', 'Precision', 'Recall']].sem().apply(lambda x: 1.96*x).reset_index()\n",
+    "    \n",
+    "    plot_df = df_means.merge(df_conf, on=['Experiment', 'Ref_Nucleotide', 'Var_Nucleotide'], suffixes=('_mean', '_conf'))\n",
+    "    counts = ['TP_Base_mean', 'TP_Call_mean', 'FP_mean', 'FN_mean']\n",
+    "    plot_df[counts] = plot_df[counts].round(2)\n",
+    "    \n",
+    "    category_orders = {\n",
+    "        'Ref_Nucleotide': ['A', 'G', 'C', 'T'],\n",
+    "        'Var_Nucleotide': ['A', 'G', 'C', 'T']\n",
+    "    }\n",
+    "    fig = px.scatter_3d(plot_df, x='Ref_Nucleotide', y='Var_Nucleotide', z=f'{stat}_mean', error_z=f'{stat}_conf', color=color, \n",
+    "                        hover_data=['TP_Base_mean', 'TP_Call_mean', 'FP_mean', 'FN_mean'],\n",
+    "                        title=f'Plot of {stat} per Substitution Type on {strat} for {type_}', \n",
+    "                        category_orders=category_orders, symbol='Substitution_Type_mean',\n",
+    "                        height=700, width=1000,\n",
+    "                       )\n",
+    "    fig.update_layout(scene_camera=dict(eye=dict(x=1.5, y=1.5, z=0.4)))\n",
+    "    return fig\n",
+    "\n",
+    "def make_titv_plot(df, stat, titv):\n",
+    "    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'\n",
+    "    strat = df['Stratifier'].iloc[0]\n",
+    "    type_ = df['Type'].iloc[0]\n",
+    "\n",
+    "    df_counts = df.groupby(['Call_Name', 'Substitution_Type', 'Experiment'])[['TP_Base', 'TP_Call', 'FP', 'FN']].sum().reset_index()\n",
+    "    df_counts['Precision'] = df_counts['TP_Call'] / (df_counts['TP_Call'] + df_counts['FP'])\n",
+    "    df_counts['Recall'] = df_counts['TP_Base'] / (df_counts['TP_Base'] + df_counts['FN'])\n",
+    "    df_counts['F1_Score'] = 2 * df_counts['Precision'] * df_counts['Recall'] / (df_counts['Precision'] + df_counts['Recall'])\n",
+    "    \n",
+    "    fig = px.histogram(df_counts, x=stat, color=color, barmode='overlay', title=f'Plot of {stat} for {titv} over {strat} for {type_}')\n",
+    "    return fig\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd675ea8-4299-40a7-8506-d92b6e2b2383",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snp_sidebar_plugins = [\n",
+    "    make_strat_selector(st_df),\n",
+    "    make_type_selector(st_df),\n",
+    "    make_experiment_selector(st_df)\n",
+    "]\n",
+    "\n",
+    "snp_substitution_plot = qbb.PlotPanel(\n",
+    "    header='SNP Substitution Plot',\n",
+    "    plotter=make_snp_substitution_plot,\n",
+    "    plot_inputs={\n",
+    "        'stat': 'F1_Score',\n",
+    "    },\n",
+    "    data_source=st_df,\n",
+    "    plugins=[\n",
+    "        plg.PlotInputRadioButtons(\n",
+    "            header='Stat to Plot',\n",
+    "            plot_input='stat',\n",
+    "            data_values=['F1_Score', 'Precision', 'Recall', 'TP_Base', 'TP_Call', 'FP', 'FN']\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "snp_titv_plot = qbb.PlotPanel(\n",
+    "    header='Distribution of Stats for Ti or Tv',\n",
+    "    plotter=make_titv_plot,\n",
+    "    plot_inputs={\n",
+    "        'stat': 'F1_Score',\n",
+    "        'titv': 'Ti',\n",
+    "    },\n",
+    "    data_source=st_df,\n",
+    "    plugins=[\n",
+    "        plg.PlotInputRadioButtons(\n",
+    "            header='Stat to Plot',\n",
+    "            plot_input='stat',\n",
+    "            data_values=['F1_Score', 'Precision', 'Recall', 'TP_Base', 'TP_Call', 'FP', 'FN']\n",
+    "        ),\n",
+    "        plg.PlotInputRadioButtons(\n",
+    "            header='Substitution Type',\n",
+    "            plot_input='titv',\n",
+    "            data_values=['Ti', 'Tv']\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "snp_cg = qbb.ContentGrid(\n",
+    "    content_list=[\n",
+    "        snp_substitution_plot,\n",
+    "        snp_titv_plot\n",
+    "    ],\n",
+    "    col_wrap=1\n",
+    ")\n",
+    "\n",
+    "snp_tab = qbb.BaseTab(\n",
+    "    tab_label='SNP Plots',\n",
+    "    tab_header='SNP Plots',\n",
+    "    content_list=[\n",
+    "        snp_cg\n",
+    "    ],\n",
+    "    sidebar_plugins=snp_sidebar_plugins\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abbb0f9f-aad6-4890-9e8d-36787937ded7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f85dbd9b-fde3-49ba-8825-e4fb3af010f8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd1675cf-f6aa-444b-bc5c-e678824700af",
+   "metadata": {},
+   "source": [
+    "## INDEL Tab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "470ac4a6-1685-4dfe-a7b5-dd19184b345b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_idd_plot(df, stat):\n",
+    "    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'\n",
+    "    strat = df['Stratifier'].iloc[0]\n",
+    "    type_ = df['Type'].iloc[0]\n",
+    "    \n",
+    "    df_means = df.groupby(['Experiment', 'INDEL_Length'])[['TP_Base', 'TP_Call', 'FP', 'FN', 'F1_Score', 'Precision', 'Recall']].mean().reset_index()\n",
+    "    # Use naive noise model for error bars\n",
+    "    df_conf = df.groupby(['Experiment', 'INDEL_Length'])[['TP_Base', 'TP_Call', 'FP', 'FN', \n",
+    "                                                          'F1_Score', 'Precision', 'Recall']].sem().apply(lambda x: 1.96*x).reset_index()\n",
+    "    \n",
+    "    df_means = df_means.round(2)\n",
+    "    df_conf = df_conf.round(4)\n",
+    "    \n",
+    "    plot_df = df_means.merge(df_conf, on=['Experiment', 'INDEL_Length'], suffixes=('_mean', '_conf'))\n",
+    "    fig = px.bar(\n",
+    "        plot_df, x='INDEL_Length', y=f'{stat}_mean', error_y=f'{stat}_conf', title=f'Plot of {stat} mean by INDEL Length on {strat} for {type_}',\n",
+    "        hover_data=['TP_Base_mean', 'TP_Call_mean', 'FP_mean', 'FN_mean'], color=color, barmode='group'\n",
+    "    )\n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac00bd23-09eb-42b7-b978-b0a152bc0a2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indel_sidebar_plugins = [\n",
+    "    make_strat_selector(idd_df),\n",
+    "    make_type_selector(idd_df),\n",
+    "    make_experiment_selector(idd_df)\n",
+    "]\n",
+    "\n",
+    "min_indel_len = min(idd_df['INDEL_Length'])\n",
+    "max_indel_len = max(idd_df['INDEL_Length'])\n",
+    "indel_len_slider_marks = {\n",
+    "    i: str(i) for i in range(min_indel_len, max_indel_len+1, 5)\n",
+    "}\n",
+    "\n",
+    "idd_plot = qbb.PlotPanel(\n",
+    "    header='InDel Distribution Plot',\n",
+    "    plotter=make_idd_plot,\n",
+    "    plot_inputs={\n",
+    "        'stat': 'F1_Score'\n",
+    "    },\n",
+    "    data_source=idd_df,\n",
+    "    plugins=[\n",
+    "        plg.PlotInputRadioButtons(\n",
+    "            header='Stat to Plot',\n",
+    "            plot_input='stat',\n",
+    "            data_values=['F1_Score', 'Precision', 'Recall']\n",
+    "        ),\n",
+    "        plg.DataFilterRangeSlider(\n",
+    "            header='Range for INDEL Length',\n",
+    "            data_col='INDEL_Length',\n",
+    "            slider_min=min_indel_len,\n",
+    "            slider_max=max_indel_len,\n",
+    "            slider_default_values=[max(-20, min_indel_len), min(20, max_indel_len)],\n",
+    "            slider_step=1,\n",
+    "            slider_marks=indel_len_slider_marks\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "indel_tab = qbb.BaseTab(\n",
+    "    tab_label='INDEL Plots',\n",
+    "    tab_header='INDEL Plots',\n",
+    "    content_list=[\n",
+    "        idd_plot\n",
+    "    ],\n",
+    "    sidebar_plugins=indel_sidebar_plugins\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b767e20-39ac-4df3-a816-6811a9500d9a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13b1edb8-2f2e-4ff6-84b2-1627be88f126",
+   "metadata": {},
+   "source": [
+    "## Main Board"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b786295d-9d47-43c2-bf93-58f67eeecc71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "board = qbb.Quickboard(\n",
+    "    tab_list=[\n",
+    "        summary_tab,\n",
+    "        snp_tab,\n",
+    "        indel_tab\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d27934b-dd22-4dfa-989b-81ea76c8b443",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_app(board, app_title='BenchmarkBoard', mode='external', port=8050)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30c93e04-2983-481a-8ce0-549312a6fa3c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3328a1f9-abb5-4318-8c91-3e1c9a708d90",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e902b609-29c1-4a1f-9421-225566ffdaab",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e12b86d7-7c23-4f54-8d52-9c7d46e438d5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "quickboard_venv",
+   "language": "python",
+   "name": "quickboard_venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-MS.ipynb
+++ b/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-MS.ipynb
@@ -247,7 +247,7 @@
     "    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'\n",
     "    marginal = marginal.lower() if marginal != 'None' else None\n",
     "    return px.scatter(df, x='Recall', y='Precision', color=color, marginal_x=marginal, marginal_y=marginal,\n",
-    "                      hover_data=['Call_Name', 'Total_Base', 'Total_Call'], title=f'Precision vs Recall Plot over {strat} for {type_}')\n",
+    "                      hover_data=['Call_Name'], title=f'Precision vs Recall Plot over {strat} for {type_}')\n",
     "\n",
     "\n",
     "def make_stat_corr_plot(df, stat_corr, stat):\n",

--- a/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-MS.py
+++ b/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-MS.py
@@ -1,0 +1,374 @@
+import pandas as pd
+import numpy as np
+import plotly.express as px
+
+import quickboard.base as qbb
+import quickboard.plugins as plg
+from quickboard.app import start_app
+
+
+## User Inputs
+
+# Users must specify column names for quantities to use in making some plots below. See the docs for details.
+# Toggle optional values here to affect behavior of generated Dashboard.
+
+# Fill with column name (or list of column names) to plot x-axis vs benchmark stats, e.g. 'Mean_Coverage' 
+# Users must edit data files to provide the data
+stat_correlator = None
+
+# Display only usual 6 variant types as options in variant type selection; Toggle to False to include other categories like MNP, MA, etc.
+simple_variants_only = True
+
+## Load Data
+
+# These file paths must point to the corresponding output files from the WDL, either saved locally or bucket links
+# In this multi-sample version, users should edit the files below prior to add columns based on desired functionality. See the docs for details.
+
+idd_df = pd.read_csv('Full_IDD.tsv', sep='\t')
+roc_df = pd.read_csv('Full_ROC.tsv', sep='\t')
+st_df = pd.read_csv('Full_ST.tsv', sep='\t')
+summary_df = pd.read_csv('SimpleSummary.tsv', sep='\t')
+
+
+### Fill Null Stratifier Entries
+
+for df in [idd_df, roc_df, st_df, summary_df]:
+    strat_values = df['Stratifier'].unique()
+    if 'Whole Genome' not in strat_values:
+        df['Stratifier'] = df['Stratifier'].fillna('Whole Genome')
+    elif 'Whole Genome (default)' in strat_values:
+        raise ValueError("Error: Rename your stratifier labels to not include either 'Whole Genome' or 'Whole Genome (default)'")
+    else:
+        df['Stratifier'] = df['Stratifier'].fillna('Whole Genome (default)')
+
+### Fill Experiment Column if not Provided
+
+for df in [idd_df, roc_df, st_df, summary_df]:
+    if 'Experiment' not in df.columns:
+        df['Experiment'] = 'No_ExpGroups_Provided'
+
+## Plugin Utilities
+
+# Constants
+simple_variants = ['SNP', 'HetSNP', 'HomVarSNP', 'INDEL', 'HetINDEL', 'HomVarINDEL']
+
+def make_strat_selector(df):
+    return plg.DataFilterRadioButtons(
+        header="Interval List",
+        data_col='Stratifier',
+        data_values=list(df['Stratifier'].unique())
+    )
+
+def make_type_selector(df):
+    if simple_variants_only:
+        variant_values = [x for x in simple_variants if x in df['Type'].unique()]
+    else:
+        variant_values = list(df['Type'].unique())
+    return plg.DataFilterRadioButtons(
+        header="Variant Type",
+        data_col='Type',
+        data_values=variant_values
+    )
+
+def make_sample_selector(df):
+    return plg.DataFilterChecklist(
+        header="Callset Sample",
+        data_col='Call_Name',
+        data_values=list(df['Call_Name'].unique())
+    )
+
+def make_experiment_selector(df):
+    return plg.DataFilterChecklist(
+        header="Experimental Groups",
+        data_col='Experiment',
+        data_values=list(df['Experiment'].unique()),
+    )
+
+
+## Summary Tab
+
+def make_prec_recall_plot(df, marginal):
+    strat = df['Stratifier'].iloc[0]
+    type_ = df['Type'].iloc[0]
+    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'
+    marginal = marginal.lower() if marginal != 'None' else None
+    return px.scatter(df, x='Recall', y='Precision', color=color, marginal_x=marginal, marginal_y=marginal,
+                      hover_data=['Call_Name', 'Total_Base', 'Total_Call'], title=f'Precision vs Recall Plot over {strat} for {type_}')
+
+
+def make_stat_corr_plot(df, stat_corr, stat):
+    strat = df['Stratifier'].iloc[0]
+    type_ = df['Type'].iloc[0]
+    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'
+    # color = 'Call_Name'
+    return px.scatter(df, x=stat_corr, y=stat, color=color, hover_data=['Call_Name', 'TP_Base', 'TP_Call', 'FP', 'FN'],
+                      title=f'Plot of {stat} by {stat_corr} over {strat} for {type_}')
+
+
+summary_sidebar_plugins = [
+    make_strat_selector(summary_df),
+    make_type_selector(summary_df),
+    make_experiment_selector(summary_df)
+]
+
+
+# Prec vs Recall plot 
+
+prec_recall_plot = qbb.PlotPanel(
+    header="Precision vs Recall Plot",
+    plotter=make_prec_recall_plot,
+    plot_inputs={
+        'marginal': 'Box'
+    },
+    data_source=summary_df,
+    plugins=[
+        plg.PlotInputRadioButtons(
+            header='Marginal Plot Type',
+            plot_input='marginal',
+            data_values=['None', 'Box', 'Violin', 'Histogram', 'Rug']
+        )
+    ]
+)
+
+
+# Stat correlator plot
+
+stat_corr_plugins = [
+    plg.PlotInputRadioButtons(
+        header='Statistic to Plot',
+        plot_input='stat',
+        data_values=['F1_Score', 'Precision', 'Recall']
+    ),
+]
+
+if stat_correlator is not None:
+    if isinstance(stat_correlator, str):
+        correlators = [stat_correlator]
+    else:
+        try: 
+            assert isinstance(stat_correlator, list)
+            correlators = stat_correlator
+            stat_corr_plugins += [
+                plg.PlotInputRadioButtons(
+                    header='Stat Correlator to Plot',
+                    plot_input='stat_corr',
+                    data_values=correlators
+                )
+            ]
+        except AssertionError:
+            print('stat_correlator must be a string or list of strings!')
+
+    stat_corr_plot = qbb.PlotPanel(
+        header="Stat Correlation Plot",
+        plotter=make_stat_corr_plot,
+        plot_inputs={
+            'stat_corr': correlators[0],
+            'stat': 'F1_Score'
+        },
+        data_source=summary_df,
+        plugins=stat_corr_plugins
+    )
+
+bench_stat_cg = qbb.ContentGrid(
+    header='Benchmarking Stat Scatter Plots',
+    content_list=[prec_recall_plot] + ([stat_corr_plot] if stat_correlator is not None else [])
+)
+
+
+summary_tab = qbb.BaseTab(
+    tab_label="Simple Summary",
+    tab_header="Plot for Simple Summary Stats",
+    content_list=[
+        bench_stat_cg
+    ],
+    sidebar_plugins=summary_sidebar_plugins
+)
+
+
+## SNP Tab
+
+st_df['Ref_Nucleotide'] = st_df['Substitution'].apply(lambda x: x.split('>')[0])
+st_df['Var_Nucleotide'] = st_df['Substitution'].apply(lambda x: x.split('>')[1])
+
+def make_snp_substitution_plot(df, stat):
+    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'
+    strat = df['Stratifier'].iloc[0]
+    type_ = df['Type'].iloc[0]
+    df_means = df.groupby(['Experiment', 'Type', 'Substitution_Type', 'Ref_Nucleotide', 'Var_Nucleotide'])[['TP_Base', 'TP_Call', 
+                                                                               'FP', 'FN', 'F1_Score', 'Precision', 'Recall']].mean().reset_index()
+    df_conf = df.groupby(['Experiment', 'Type', 'Substitution_Type', 'Ref_Nucleotide', 'Var_Nucleotide'])[[
+        'TP_Base', 'TP_Call', 'FP', 'FN', 'F1_Score', 'Precision', 'Recall']].sem().apply(lambda x: 1.96*x).reset_index()
+    
+    plot_df = df_means.merge(df_conf, on=['Experiment', 'Ref_Nucleotide', 'Var_Nucleotide'], suffixes=('_mean', '_conf'))
+    counts = ['TP_Base_mean', 'TP_Call_mean', 'FP_mean', 'FN_mean']
+    plot_df[counts] = plot_df[counts].round(2)
+    
+    category_orders = {
+        'Ref_Nucleotide': ['A', 'G', 'C', 'T'],
+        'Var_Nucleotide': ['A', 'G', 'C', 'T']
+    }
+    fig = px.scatter_3d(plot_df, x='Ref_Nucleotide', y='Var_Nucleotide', z=f'{stat}_mean', error_z=f'{stat}_conf', color=color, 
+                        hover_data=['TP_Base_mean', 'TP_Call_mean', 'FP_mean', 'FN_mean'],
+                        title=f'Plot of {stat} per Substitution Type on {strat} for {type_}', 
+                        category_orders=category_orders, symbol='Substitution_Type_mean',
+                        height=700, width=1000,
+                       )
+    fig.update_layout(scene_camera=dict(eye=dict(x=1.5, y=1.5, z=0.4)))
+    return fig
+
+def make_titv_plot(df, stat, titv):
+    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'
+    strat = df['Stratifier'].iloc[0]
+    type_ = df['Type'].iloc[0]
+
+    df_counts = df.groupby(['Call_Name', 'Substitution_Type', 'Experiment'])[['TP_Base', 'TP_Call', 'FP', 'FN']].sum().reset_index()
+    df_counts['Precision'] = df_counts['TP_Call'] / (df_counts['TP_Call'] + df_counts['FP'])
+    df_counts['Recall'] = df_counts['TP_Base'] / (df_counts['TP_Base'] + df_counts['FN'])
+    df_counts['F1_Score'] = 2 * df_counts['Precision'] * df_counts['Recall'] / (df_counts['Precision'] + df_counts['Recall'])
+    
+    fig = px.histogram(df_counts, x=stat, color=color, barmode='overlay', title=f'Plot of {stat} for {titv} over {strat} for {type_}')
+    return fig
+    
+
+snp_sidebar_plugins = [
+    make_strat_selector(st_df),
+    make_type_selector(st_df),
+    make_experiment_selector(st_df)
+]
+
+snp_substitution_plot = qbb.PlotPanel(
+    header='SNP Substitution Plot',
+    plotter=make_snp_substitution_plot,
+    plot_inputs={
+        'stat': 'F1_Score',
+    },
+    data_source=st_df,
+    plugins=[
+        plg.PlotInputRadioButtons(
+            header='Stat to Plot',
+            plot_input='stat',
+            data_values=['F1_Score', 'Precision', 'Recall', 'TP_Base', 'TP_Call', 'FP', 'FN']
+        )
+    ]
+)
+
+snp_titv_plot = qbb.PlotPanel(
+    header='Distribution of Stats for Ti or Tv',
+    plotter=make_titv_plot,
+    plot_inputs={
+        'stat': 'F1_Score',
+        'titv': 'Ti',
+    },
+    data_source=st_df,
+    plugins=[
+        plg.PlotInputRadioButtons(
+            header='Stat to Plot',
+            plot_input='stat',
+            data_values=['F1_Score', 'Precision', 'Recall', 'TP_Base', 'TP_Call', 'FP', 'FN']
+        ),
+        plg.PlotInputRadioButtons(
+            header='Substitution Type',
+            plot_input='titv',
+            data_values=['Ti', 'Tv']
+        )
+    ]
+)
+
+snp_cg = qbb.ContentGrid(
+    content_list=[
+        snp_substitution_plot,
+        snp_titv_plot
+    ],
+    col_wrap=1
+)
+
+snp_tab = qbb.BaseTab(
+    tab_label='SNP Plots',
+    tab_header='SNP Plots',
+    content_list=[
+        snp_cg
+    ],
+    sidebar_plugins=snp_sidebar_plugins
+)
+
+
+## INDEL Tab
+
+def make_idd_plot(df, stat):
+    color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'
+    strat = df['Stratifier'].iloc[0]
+    type_ = df['Type'].iloc[0]
+    
+    df_means = df.groupby(['Experiment', 'INDEL_Length'])[['TP_Base', 'TP_Call', 'FP', 'FN', 'F1_Score', 'Precision', 'Recall']].mean().reset_index()
+    # Use naive noise model for error bars
+    df_conf = df.groupby(['Experiment', 'INDEL_Length'])[['TP_Base', 'TP_Call', 'FP', 'FN', 
+                                                          'F1_Score', 'Precision', 'Recall']].sem().apply(lambda x: 1.96*x).reset_index()
+    
+    df_means = df_means.round(2)
+    df_conf = df_conf.round(4)
+    
+    plot_df = df_means.merge(df_conf, on=['Experiment', 'INDEL_Length'], suffixes=('_mean', '_conf'))
+    fig = px.bar(
+        plot_df, x='INDEL_Length', y=f'{stat}_mean', error_y=f'{stat}_conf', title=f'Plot of {stat} mean by INDEL Length on {strat} for {type_}',
+        hover_data=['TP_Base_mean', 'TP_Call_mean', 'FP_mean', 'FN_mean'], color=color, barmode='group'
+    )
+    return fig
+
+indel_sidebar_plugins = [
+    make_strat_selector(idd_df),
+    make_type_selector(idd_df),
+    make_experiment_selector(idd_df)
+]
+
+min_indel_len = min(idd_df['INDEL_Length'])
+max_indel_len = max(idd_df['INDEL_Length'])
+indel_len_slider_marks = {
+    i: str(i) for i in range(min_indel_len, max_indel_len+1, 5)
+}
+
+idd_plot = qbb.PlotPanel(
+    header='InDel Distribution Plot',
+    plotter=make_idd_plot,
+    plot_inputs={
+        'stat': 'F1_Score'
+    },
+    data_source=idd_df,
+    plugins=[
+        plg.PlotInputRadioButtons(
+            header='Stat to Plot',
+            plot_input='stat',
+            data_values=['F1_Score', 'Precision', 'Recall']
+        ),
+        plg.DataFilterRangeSlider(
+            header='Range for INDEL Length',
+            data_col='INDEL_Length',
+            slider_min=min_indel_len,
+            slider_max=max_indel_len,
+            slider_default_values=[max(-20, min_indel_len), min(20, max_indel_len)],
+            slider_step=1,
+            slider_marks=indel_len_slider_marks
+        )
+    ]
+)
+
+indel_tab = qbb.BaseTab(
+    tab_label='INDEL Plots',
+    tab_header='INDEL Plots',
+    content_list=[
+        idd_plot
+    ],
+    sidebar_plugins=indel_sidebar_plugins
+)
+
+
+## Main Board
+
+board = qbb.Quickboard(
+    tab_list=[
+        summary_tab,
+        snp_tab,
+        indel_tab
+    ]
+)
+
+start_app(board, app_title='BenchmarkBoard', mode='external', port=8050)

--- a/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-MS.py
+++ b/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-MS.py
@@ -93,7 +93,7 @@ def make_prec_recall_plot(df, marginal):
     color = None if df['Experiment'].iloc[0] == 'No_ExpGroups_Provided' else 'Experiment'
     marginal = marginal.lower() if marginal != 'None' else None
     return px.scatter(df, x='Recall', y='Precision', color=color, marginal_x=marginal, marginal_y=marginal,
-                      hover_data=['Call_Name', 'Total_Base', 'Total_Call'], title=f'Precision vs Recall Plot over {strat} for {type_}')
+                      hover_data=['Call_Name'], title=f'Precision vs Recall Plot over {strat} for {type_}')
 
 
 def make_stat_corr_plot(df, stat_corr, stat):

--- a/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-SS.ipynb
+++ b/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-SS.ipynb
@@ -1,0 +1,562 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "026481f0-9180-467b-893d-3c3426c8748f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.express as px\n",
+    "\n",
+    "import quickboard.base as qbb\n",
+    "import quickboard.plugins as plg\n",
+    "from quickboard.app import start_app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "909ade3d-62d7-41e2-9f4b-05ec9779938e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "738269b8-45c4-4dd7-9d70-49084e161dad",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77f7977f-cde4-4f37-a766-c33a6ac8f808",
+   "metadata": {},
+   "source": [
+    "## Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0af1be0-129b-4b2e-8aca-5a921cb70e7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These file paths must point to the corresponding output files from the WDL, either saved locally or bucket links\n",
+    "\n",
+    "idd_df = pd.read_csv('Full_IDD.tsv', sep='\\t')\n",
+    "roc_df = pd.read_csv('Full_ROC.tsv', sep='\\t')\n",
+    "st_df = pd.read_csv('Full_ST.tsv', sep='\\t')\n",
+    "summary_df = pd.read_csv('SimpleSummary.tsv', sep='\\t')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62cb344e-74b8-44aa-8819-0cabec98c1b5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b9cd773-b359-48a0-892c-7c3853dd4fa1",
+   "metadata": {},
+   "source": [
+    "### Fill Null Stratifier Entries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61925f2d-a842-4f62-8770-5f0083f4ce8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for df in [idd_df, roc_df, st_df, summary_df]:\n",
+    "    strat_values = df['Stratifier'].unique()\n",
+    "    if 'Whole Genome' not in strat_values:\n",
+    "        df['Stratifier'] = df['Stratifier'].fillna('Whole Genome')\n",
+    "    elif 'Whole Genome (default)' in strat_values:\n",
+    "        raise ValueError(\"Error: Rename your stratifier labels to not include either 'Whole Genome' or 'Whole Genome (default)'\")\n",
+    "    else:\n",
+    "        df['Stratifier'] = df['Stratifier'].fillana('Whole Genome (default)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "207a06d1-4865-4691-8065-3bf1cc31fd5e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cca24a77-88ee-47d4-bfe9-eaedd6ad1ba8",
+   "metadata": {},
+   "source": [
+    "## Plugin Utilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a37b394-cae0-4abb-8d98-ee3bf5795175",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_strat_selector(df):\n",
+    "    return plg.DataFilterRadioButtons(\n",
+    "        header=\"Interval List\",\n",
+    "        data_col='Stratifier',\n",
+    "        data_values=list(df['Stratifier'].unique())\n",
+    "    )\n",
+    "\n",
+    "def make_type_selector(df):\n",
+    "    return plg.DataFilterRadioButtons(\n",
+    "        header=\"Variant Type\",\n",
+    "        data_col='Type',\n",
+    "        data_values=list(df['Type'].unique())\n",
+    "    )\n",
+    "\n",
+    "def make_sample_selector(df):\n",
+    "    return plg.DataFilterRadioButtons(\n",
+    "        header=\"Callset Sample\",\n",
+    "        data_col='Call_Name',\n",
+    "        data_values=list(df['Call_Name'].unique())\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8ec870c-c0bd-4c20-9beb-77bef21bc438",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5246edc-cccb-496f-90a2-ecbd8b75072d",
+   "metadata": {},
+   "source": [
+    "## Summary Tab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cc87066-d952-4a7c-9ec6-cbac0b55cf44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary_sidebar_plugins = [\n",
+    "    plg.DataFilterChecklist(\n",
+    "        header=\"Interval List\",\n",
+    "        data_col='Stratifier',\n",
+    "        data_values=list(df['Stratifier'].unique())\n",
+    "    ),\n",
+    "    plg.DataFilterChecklist(\n",
+    "        header=\"Variant Type\",\n",
+    "        data_col='Type',\n",
+    "        data_values=list(df['Type'].unique())\n",
+    "    )\n",
+    "]\n",
+    "\n",
+    "summary_body_text = f\"\"\"This table contains counts of benchmarking statistics (FP, Precision, etc.) for each \n",
+    "sample across various interval stratifiers and variant subtypes. \n",
+    "\n",
+    "You can filter the table below by typing into the fields above each column. \n",
+    "\n",
+    "E.g. type 'SNP' in the Type column to see stats on variant types containing the string 'SNP' only, or '=SNP' for just those with value exactly 'SNP'.\n",
+    "\n",
+    "You can also sort values in a column alphabetically/ascending using the arrows on the left of the column title. Use syntax like '>0.75' to set \n",
+    "thresholds to filter by.\n",
+    "\"\"\"\n",
+    "\n",
+    "# Round entries to shorten table column width\n",
+    "summary_df = summary_df.round(4)\n",
+    "\n",
+    "summary_table = qbb.DataPanel(\n",
+    "    header='Summary Table',\n",
+    "    body=summary_body_text,\n",
+    "    data_source=summary_df,\n",
+    ")\n",
+    "\n",
+    "summary_tab = qbb.BaseTab(\n",
+    "    tab_label='Summary Stats',\n",
+    "    tab_header='Summary Statistics',\n",
+    "    content_list=[\n",
+    "        summary_table\n",
+    "    ],\n",
+    "    sidebar_plugins=summary_sidebar_plugins\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e5fc43c-9a14-43f4-97c3-0ec4358eb70a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01e3675d-ae75-4ea8-a3af-81d053e11838",
+   "metadata": {},
+   "source": [
+    "## ROC Tab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b408f9a9-0209-47ed-a368-810535787b7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_roc_plot(df, score_field, tp):\n",
+    "    tp_value = f'TP_{tp}'\n",
+    "    color = f'{tp}_Name'\n",
+    "    strat = df['Stratifier'].iloc[0]\n",
+    "    type_ = df['Type'].iloc[0]\n",
+    "    fig = px.line(df, x='Score', y='Precision', hover_data=['Score', 'Score_Field', 'TP_Base', 'TP_Call', 'FP', 'FN'], \n",
+    "                  title=f'ROC Plot on {strat} for {type_} by {score_field}', color=color)\n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b2da5b2-8074-4aac-959f-c4243400b4f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "roc_sidebar_plugins = [\n",
+    "    make_strat_selector(roc_df),\n",
+    "    make_type_selector(roc_df),\n",
+    "    plg.DataFilterRadioButtons(\n",
+    "        header=\"Score Field\",\n",
+    "        data_col='Score_Field',\n",
+    "        data_values=list(roc_df['Score_Field'].unique())\n",
+    "    ),\n",
+    "    make_sample_selector(roc_df)\n",
+    "]\n",
+    "\n",
+    "roc_plot = qbb.PlotPanel(\n",
+    "    header=\"ROC Plot (TP vs FP by Score Field)\",\n",
+    "    plotter=make_roc_plot,\n",
+    "    plot_inputs={\n",
+    "        'score_field': roc_df['Score_Field'].iloc[0],\n",
+    "        'tp': 'Call'\n",
+    "    },\n",
+    "    data_source=roc_df,\n",
+    "    plugins=[]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c45804e9-10c8-4266-b242-127eadf41a62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "roc_tab = qbb.BaseTab(\n",
+    "    tab_label='ROC Plots',\n",
+    "    tab_header='ROC Plots',\n",
+    "    content_list=[\n",
+    "        roc_plot\n",
+    "    ],\n",
+    "    sidebar_plugins=roc_sidebar_plugins\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "015af893-4e51-4ebe-999c-93b2293e4b84",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "586457c0-f2b7-4cab-a387-284008eb51a2",
+   "metadata": {},
+   "source": [
+    "## SNP Tab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24f6cda8-bb2f-4448-ac1d-d19dc9ff6b06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st_df['Ref_Nucleotide'] = st_df['Substitution'].apply(lambda x: x.split('>')[0])\n",
+    "st_df['Var_Nucleotide'] = st_df['Substitution'].apply(lambda x: x.split('>')[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47e2bb8b-3eef-425a-8e7a-643e2f069d70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_snp_plot(df, stat):\n",
+    "    strat = df['Stratifier'].iloc[0]\n",
+    "    type_ = df['Type'].iloc[0]\n",
+    "    category_orders = {\n",
+    "        'Ref_Nucleotide': ['A', 'G', 'C', 'T'],\n",
+    "        'Var_Nucleotide': ['A', 'G', 'C', 'T']\n",
+    "    }\n",
+    "    fig = px.scatter_3d(df, x='Ref_Nucleotide', y='Var_Nucleotide', z=stat, color='Substitution_Type', \n",
+    "                        hover_data=['TP_Base', 'TP_Call', 'FP', 'FN'],\n",
+    "                        title=f'Plot of {stat} per Substitution Type on {strat} for {type_}', \n",
+    "                        category_orders=category_orders,\n",
+    "                        height=700, width=1000,\n",
+    "                       )\n",
+    "    fig.update_layout(scene_camera=dict(eye=dict(x=1.5, y=1.5, z=0.4)))\n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1b29a42-45ef-4a01-a69f-ec1771cb44a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snp_sidebar_plugins = [\n",
+    "    make_strat_selector(st_df),\n",
+    "    make_type_selector(st_df),\n",
+    "    make_sample_selector(st_df)\n",
+    "]\n",
+    "\n",
+    "snp_plot = qbb.PlotPanel(\n",
+    "    header='SNP Substitution Plot',\n",
+    "    plotter=make_snp_plot,\n",
+    "    plot_inputs={\n",
+    "        'stat': 'F1_Score',\n",
+    "    },\n",
+    "    data_source=st_df,\n",
+    "    plugins=[\n",
+    "        plg.PlotInputRadioButtons(\n",
+    "            header='Stat to Plot',\n",
+    "            plot_input='stat',\n",
+    "            data_values=['F1_Score', 'Precision', 'Recall', 'TP_Base', 'TP_Call', 'FP', 'FN']\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "snp_tab = qbb.BaseTab(\n",
+    "    tab_label='SNP Plots',\n",
+    "    tab_header='SNP Plots',\n",
+    "    content_list=[\n",
+    "        snp_plot\n",
+    "    ],\n",
+    "    sidebar_plugins=snp_sidebar_plugins\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e69935d1-f16d-4549-a859-4ad1da737f29",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e30aad9d-ba55-4a17-aa5d-e30ed6c927c5",
+   "metadata": {},
+   "source": [
+    "## INDEL Tab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79f679ee-7214-4118-b566-855262e4a607",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_idd_plot(df, stat):\n",
+    "    strat = df['Stratifier'].iloc[0]\n",
+    "    type_ = df['Type'].iloc[0]\n",
+    "    fig = px.bar(df, x='INDEL_Length', y=stat, title=f'Plot of {stat} by INDEL Length on {strat} for {type_}',\n",
+    "                hover_data=['TP_Base', 'TP_Call', 'FP', 'FN'])\n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd63152c-7453-422b-9e7e-d9f7b51d7577",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indel_sidebar_plugins = [\n",
+    "    make_strat_selector(idd_df),\n",
+    "    make_type_selector(idd_df),\n",
+    "    make_sample_selector(idd_df)\n",
+    "]\n",
+    "\n",
+    "min_indel_len = min(idd_df['INDEL_Length'])\n",
+    "max_indel_len = max(idd_df['INDEL_Length'])\n",
+    "indel_len_slider_marks = {\n",
+    "    i: str(i) for i in range(min_indel_len, max_indel_len+1, 5)\n",
+    "}\n",
+    "\n",
+    "idd_plot = qbb.PlotPanel(\n",
+    "    header='InDel Distribution Plot',\n",
+    "    plotter=make_idd_plot,\n",
+    "    plot_inputs={\n",
+    "        'stat': 'F1_Score'\n",
+    "    },\n",
+    "    data_source=idd_df,\n",
+    "    plugins=[\n",
+    "        plg.PlotInputRadioButtons(\n",
+    "            header='Stat to Plot',\n",
+    "            plot_input='stat',\n",
+    "            data_values=['F1_Score', 'Precision', 'Recall']\n",
+    "        ),\n",
+    "        plg.DataFilterRangeSlider(\n",
+    "            header='Range for INDEL Length',\n",
+    "            data_col='INDEL_Length',\n",
+    "            slider_min=min_indel_len,\n",
+    "            slider_max=max_indel_len,\n",
+    "            slider_default_values=[max(-20, min_indel_len), min(20, max_indel_len)],\n",
+    "            slider_step=1,\n",
+    "            slider_marks=indel_len_slider_marks\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "indel_tab = qbb.BaseTab(\n",
+    "    tab_label='INDEL Plots',\n",
+    "    tab_header='INDEL Plots',\n",
+    "    content_list=[\n",
+    "        idd_plot\n",
+    "    ],\n",
+    "    sidebar_plugins=indel_sidebar_plugins\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69107eb6-baed-479c-b317-396d002a35cf",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4b4929e-9ad7-4a8c-9d6b-99daeaa95201",
+   "metadata": {},
+   "source": [
+    "## Main Board"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca10f963-7e79-4810-aa62-77ac56cc47af",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5859cb45-4247-4f8b-9401-9a20aa204896",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "board = qbb.Quickboard(\n",
+    "    tab_list=[\n",
+    "        summary_tab,\n",
+    "        roc_tab,\n",
+    "        snp_tab,\n",
+    "        indel_tab\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1682fca-d923-48bd-bf52-fa253ca47f61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_app(board, app_title='BenchmarkBoard', mode='external', port=8050)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "500228b8-95f1-494e-bd8b-eb14df6e4221",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99b21ecb-ac53-4d82-b2b4-644f0146db9f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "792d96f2-215e-4de4-b98f-fd7cb92af9cb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15ef26c4-7579-44cf-9a8d-968994cce193",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "quickboard_venv",
+   "language": "python",
+   "name": "quickboard_venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-SS.py
+++ b/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard-SS.py
@@ -1,0 +1,258 @@
+import pandas as pd
+import numpy as np
+import plotly.express as px
+
+import quickboard.base as qbb
+import quickboard.plugins as plg
+from quickboard.app import start_app
+
+
+## Load Data
+
+# These file paths must point to the corresponding output files from the WDL, either saved locally or bucket links
+
+idd_df = pd.read_csv('Full_IDD.tsv', sep='\t')
+roc_df = pd.read_csv('Full_ROC.tsv', sep='\t')
+st_df = pd.read_csv('Full_ST.tsv', sep='\t')
+summary_df = pd.read_csv('SimpleSummary.tsv', sep='\t')
+
+
+### Fill Null Stratifier Entries
+
+for df in [idd_df, roc_df, st_df, summary_df]:
+    strat_values = df['Stratifier'].unique()
+    if 'Whole Genome' not in strat_values:
+        df['Stratifier'] = df['Stratifier'].fillna('Whole Genome')
+    elif 'Whole Genome (default)' in strat_values:
+        raise ValueError("Error: Rename your stratifier labels to not include either 'Whole Genome' or 'Whole Genome (default)'")
+    else:
+        df['Stratifier'] = df['Stratifier'].fillana('Whole Genome (default)')
+
+## Plugin Utilities
+
+def make_strat_selector(df):
+    return plg.DataFilterRadioButtons(
+        header="Interval List",
+        data_col='Stratifier',
+        data_values=list(df['Stratifier'].unique())
+    )
+
+def make_type_selector(df):
+    return plg.DataFilterRadioButtons(
+        header="Variant Type",
+        data_col='Type',
+        data_values=list(df['Type'].unique())
+    )
+
+def make_sample_selector(df):
+    return plg.DataFilterRadioButtons(
+        header="Callset Sample",
+        data_col='Call_Name',
+        data_values=list(df['Call_Name'].unique())
+    )
+
+## Summary Tab
+
+summary_sidebar_plugins = [
+    plg.DataFilterChecklist(
+        header="Interval List",
+        data_col='Stratifier',
+        data_values=list(df['Stratifier'].unique())
+    ),
+    plg.DataFilterChecklist(
+        header="Variant Type",
+        data_col='Type',
+        data_values=list(df['Type'].unique())
+    )
+]
+
+summary_body_text = f"""This table contains counts of benchmarking statistics (FP, Precision, etc.) for each 
+sample across various interval stratifiers and variant subtypes. 
+
+You can filter the table below by typing into the fields above each column. 
+
+E.g. type 'SNP' in the Type column to see stats on variant types containing the string 'SNP' only, or '=SNP' for just those with value exactly 'SNP'.
+
+You can also sort values in a column alphabetically/ascending using the arrows on the left of the column title. Use syntax like '>0.75' to set 
+thresholds to filter by.
+"""
+
+# Round entries to shorten table column width
+summary_df = summary_df.round(4)
+
+summary_table = qbb.DataPanel(
+    header='Summary Table',
+    body=summary_body_text,
+    data_source=summary_df,
+)
+
+summary_tab = qbb.BaseTab(
+    tab_label='Summary Stats',
+    tab_header='Summary Statistics',
+    content_list=[
+        summary_table
+    ],
+    sidebar_plugins=summary_sidebar_plugins
+)
+
+## ROC Tab
+
+def make_roc_plot(df, score_field, tp):
+    tp_value = f'TP_{tp}'
+    color = f'{tp}_Name'
+    strat = df['Stratifier'].iloc[0]
+    type_ = df['Type'].iloc[0]
+    fig = px.line(df, x='Score', y='Precision', hover_data=['Score', 'Score_Field', 'TP_Base', 'TP_Call', 'FP', 'FN'], 
+                  title=f'ROC Plot on {strat} for {type_} by {score_field}', color=color)
+    return fig
+
+roc_sidebar_plugins = [
+    make_strat_selector(roc_df),
+    make_type_selector(roc_df),
+    plg.DataFilterRadioButtons(
+        header="Score Field",
+        data_col='Score_Field',
+        data_values=list(roc_df['Score_Field'].unique())
+    ),
+    make_sample_selector(roc_df)
+]
+
+roc_plot = qbb.PlotPanel(
+    header="ROC Plot (TP vs FP by Score Field)",
+    plotter=make_roc_plot,
+    plot_inputs={
+        'score_field': roc_df['Score_Field'].iloc[0],
+        'tp': 'Call'
+    },
+    data_source=roc_df,
+    plugins=[]
+)
+
+roc_tab = qbb.BaseTab(
+    tab_label='ROC Plots',
+    tab_header='ROC Plots',
+    content_list=[
+        roc_plot
+    ],
+    sidebar_plugins=roc_sidebar_plugins
+)
+
+## SNP Tab
+
+st_df['Ref_Nucleotide'] = st_df['Substitution'].apply(lambda x: x.split('>')[0])
+st_df['Var_Nucleotide'] = st_df['Substitution'].apply(lambda x: x.split('>')[1])
+
+def make_snp_plot(df, stat):
+    strat = df['Stratifier'].iloc[0]
+    type_ = df['Type'].iloc[0]
+    category_orders = {
+        'Ref_Nucleotide': ['A', 'G', 'C', 'T'],
+        'Var_Nucleotide': ['A', 'G', 'C', 'T']
+    }
+    fig = px.scatter_3d(df, x='Ref_Nucleotide', y='Var_Nucleotide', z=stat, color='Substitution_Type', 
+                        hover_data=['TP_Base', 'TP_Call', 'FP', 'FN'],
+                        title=f'Plot of {stat} per Substitution Type on {strat} for {type_}', 
+                        category_orders=category_orders,
+                        height=700, width=1000,
+                       )
+    fig.update_layout(scene_camera=dict(eye=dict(x=1.5, y=1.5, z=0.4)))
+    return fig
+
+snp_sidebar_plugins = [
+    make_strat_selector(st_df),
+    make_type_selector(st_df),
+    make_sample_selector(st_df)
+]
+
+snp_plot = qbb.PlotPanel(
+    header='SNP Substitution Plot',
+    plotter=make_snp_plot,
+    plot_inputs={
+        'stat': 'F1_Score',
+    },
+    data_source=st_df,
+    plugins=[
+        plg.PlotInputRadioButtons(
+            header='Stat to Plot',
+            plot_input='stat',
+            data_values=['F1_Score', 'Precision', 'Recall', 'TP_Base', 'TP_Call', 'FP', 'FN']
+        )
+    ]
+)
+
+snp_tab = qbb.BaseTab(
+    tab_label='SNP Plots',
+    tab_header='SNP Plots',
+    content_list=[
+        snp_plot
+    ],
+    sidebar_plugins=snp_sidebar_plugins
+)
+
+## INDEL Tab
+
+def make_idd_plot(df, stat):
+    strat = df['Stratifier'].iloc[0]
+    type_ = df['Type'].iloc[0]
+    fig = px.bar(df, x='INDEL_Length', y=stat, title=f'Plot of {stat} by INDEL Length on {strat} for {type_}',
+                hover_data=['TP_Base', 'TP_Call', 'FP', 'FN'])
+    return fig
+
+indel_sidebar_plugins = [
+    make_strat_selector(idd_df),
+    make_type_selector(idd_df),
+    make_sample_selector(idd_df)
+]
+
+min_indel_len = min(idd_df['INDEL_Length'])
+max_indel_len = max(idd_df['INDEL_Length'])
+indel_len_slider_marks = {
+    i: str(i) for i in range(min_indel_len, max_indel_len+1, 5)
+}
+
+idd_plot = qbb.PlotPanel(
+    header='InDel Distribution Plot',
+    plotter=make_idd_plot,
+    plot_inputs={
+        'stat': 'F1_Score'
+    },
+    data_source=idd_df,
+    plugins=[
+        plg.PlotInputRadioButtons(
+            header='Stat to Plot',
+            plot_input='stat',
+            data_values=['F1_Score', 'Precision', 'Recall']
+        ),
+        plg.DataFilterRangeSlider(
+            header='Range for INDEL Length',
+            data_col='INDEL_Length',
+            slider_min=min_indel_len,
+            slider_max=max_indel_len,
+            slider_default_values=[max(-20, min_indel_len), min(20, max_indel_len)],
+            slider_step=1,
+            slider_marks=indel_len_slider_marks
+        )
+    ]
+)
+
+indel_tab = qbb.BaseTab(
+    tab_label='INDEL Plots',
+    tab_header='INDEL Plots',
+    content_list=[
+        idd_plot
+    ],
+    sidebar_plugins=indel_sidebar_plugins
+)
+
+## Main Board
+
+board = qbb.Quickboard(
+    tab_list=[
+        summary_tab,
+        roc_tab,
+        snp_tab,
+        indel_tab
+    ]
+)
+
+start_app(board, app_title='BenchmarkBoard', mode='external', port=8050)

--- a/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard_README.md
+++ b/BenchmarkVCFs/BenchmarkBoard/BenchmarkBoard_README.md
@@ -1,0 +1,60 @@
+# BenchmarkBoard
+
+BenchmarkBoard is an interactive visualizer meant to complement the [SimpleBenchmark](../SimpleBenchmark.wdl) WDL tool for 
+benchmarking VCFs. It is easy to setup for use with data output from the WDL, and can be thought of as a template or inspiration 
+for ways to visualize the large amounts of data produced.
+
+## Quickstart
+
+To use the BenchmarkBoard, you must satisfy the following requirements:
+1. Have a Python environment with [Quickboard](https://github.com/broadinstitute/quickboard) installed, e.g. `pip install quickboard`.
+2. Have the files output by the SimpleBenchmark tool saved locally.
+3. Have a copy of the benchmarkboard-\*.py or benchmarkboard-\*.ipynb file saved in the *same* directory as the files from 
+the WDL. These come in two flavors: SS (single-sample mode) or MS (multi-sample mode). If you have just one sample pair to 
+analyze, use the file with `-SS`. Otherwise if you have multiple sample pairs and concatenated the outputs from multiple WDL 
+runs, use the file with `-MS`.
+
+Once you satisfy those requirements, you can either run the `.py` file or run all the cells in the `.ipynb` file to start 
+up the dashboard server. You can connect to it by going to `localhost:8050` in any web browser, or clicking the output 
+link if running in Jupyter. If this port is already in use for another application, you can do a find and replace in the 
+Python files for `port=8050` and replace with a free port on your system.
+
+## Overview
+
+When opening the dashboard, you will see various tabs on the top of the screen with can be clicked on to see new pages of 
+plots. These are separated into a few different categories based on the different files produced by the WDL. On the side 
+and below many plots, there are plugins, i.e. buttons or sliders, that can manipulate the data being displayed in the 
+plot. In particular, every page has a sidebar plugin which controls which interval file the data is being stratified 
+by, and what type of variant data is being displayed.
+
+Although both boards should support multi-sample data tables, the style in which they display data is geared towards the 
+two different applications. The single-sample board contains an interactive table on the `Summary Stats` page, which lets 
+users query the output summary statistics. The `Callset Sample` sidebar plugin ensures users only see data for one 
+sample at a time, with the option to toggle between them with radio buttons (in the case the underlying data tables have 
+been modified via concating outputs from multiple WDL runs).
+
+The multi-sample board, on the other hand, is geared towards visualizing groups of VCFs, with the prototypical application 
+being a comparison between different experiment groups, coming from the `Experiment` column defined by users either 
+in the WDL run, or in a pre-processing step the user is responsible for. Plots here will be colored by this column, 
+if present. The same SNP and INDEL tab plots are in this board, but instead represent averages done over the 
+`Experiment` groups. Experiment groups to include in visualizations can be toggled using the sidebar checklist, 
+instead of having to manually exclude them in each Plotly plot by clicking on the color group each time a plot is regenerated.
+
+## Custom Usage
+
+Aside from allowing for user-defined experiment groups to manipulate the multi-sample board, there are a few other options 
+users can configure to change the behavior of the dashboards produced, by editing the top of the Python files themselves.
+
+In the multi-sample board, users can find the following variables to be optionally edited:
+* `stat_correlator` - (default = None) This can be a string, or list of strings, which are column names the user might 
+want to control for when doing comparisons of statistics like Precision, Recall, etc. When turned on (via providing legal values), 
+this feature will introduce an extra plot in the `Simple Summary` tab called `Stat Correlation Plot`. The y-axis will plot whatever 
+statistics is desired by the user (e.g. Precision), whereas the x-axis can be toggled via radio buttons to be any entry 
+in the `stat_correlator` list. A popular use case would be to use user-provided `MEAN_COVERAGE` as a value, as this 
+often correlates with benchmarking performance. This would require the user to either manually edit the files after running 
+the WDL, or to provide them via e.g. the Terra table through the `extra_column` and `extra_column_label` arguments.
+* `simple_variants_only` - (default = True) This is a boolean which controls which types of variants are available as 
+options when plotting on the `Simple Summary` tab. When True, this restricts the options to the usual variant types: 
+SNP, HetSNP, HomVarSNP, INDEL, HetINDEL, and HomVarINDEL. Otherwise, a number of other `bcftools` categories like MA 
+(multiallelic sites), Other, etc. are available. This is toggled off by default, since those types of variants are often 
+much more rare, and their statistics can be more distracting than insightful.

--- a/BenchmarkVCFs/SimpleBenchmark.wdl
+++ b/BenchmarkVCFs/SimpleBenchmark.wdl
@@ -414,7 +414,7 @@ task BCFToolsStats {
         full_sn_df = pd.DataFrame({'Category': df_dict['TP_Base']['SN_df']['Category']})
         for stat in df_dict:
             full_sn_df = df_dict[stat]['SN_df'].rename(columns={'Count': f'{stat}_Count'}).merge(full_sn_df, on='Category', how='outer')
-        full_sn_df.fillna(0)
+        full_sn_df = full_sn_df.fillna(0)
         full_sn_df['Call_Name'] = "~{call_output_sample_name}"
         full_sn_df['Base_Name'] = "~{base_output_sample_name}"
         full_sn_df['Stratifier'] = "~{strat_label}"
@@ -424,7 +424,7 @@ task BCFToolsStats {
         full_idd_df = pd.DataFrame({'INDEL_Length': df_dict['TP_Base']['IDD_df']['INDEL_Length']})
         for stat in df_dict:
             full_idd_df = df_dict[stat]['IDD_df'].rename(columns={'Count': f'{stat}_Count'}).merge(full_idd_df, on='INDEL_Length', how='outer')
-        full_idd_df.fillna(0)
+        full_idd_df = full_idd_df.fillna(0)
         full_idd_df['Call_Name'] = "~{call_output_sample_name}"
         full_idd_df['Base_Name'] = "~{base_output_sample_name}"
         full_idd_df['Stratifier'] = "~{strat_label}"

--- a/BenchmarkVCFs/SimpleBenchmark.wdl
+++ b/BenchmarkVCFs/SimpleBenchmark.wdl
@@ -286,9 +286,17 @@ task VCFEval {
         roc_summary = pd.DataFrame()
         for Type in ['snp', 'mnp', 'indel']:
             file_path = f'output_dir/{Type}_roc.tsv.gz'
+
+            header_lines = []
+            # Read through file lines until hitting one without leading '#'
             with gzip.open(file_path, 'rt') as file:
                 roc = [line for line in file.readlines()]
-            header_names = [line.replace('#', '').replace('\n', '') for line in roc if '#' in line][-1].split('\t')
+                for line in file:
+                    if line[0] == '#':
+                        header_lines += [line]
+                    else:
+                        break
+            header_names = header_lines[-1].replace('#', '').replace('\n', '').split('\t')
             df = pd.read_csv(file_path, sep='\t', comment='#', header=None, names=header_names)
 
             rename_columns = {'score': 'Score', 'true_positives_baseline': 'TP_Base',
@@ -354,8 +362,8 @@ task BCFToolsStats {
         File? evaluation_bed
 
         Int disk_size = ceil(size(tp_base_vcf, "GB") + size(tp_call_vcf, "GB") + size(fp_vcf, "GB") + size(fn_vcf, "GB")) + 20
-        Int cpu = 16
-        Int memory = 32
+        Int cpu = 8
+        Int memory = 16
     }
 
     # Handle parsing bcf_selector with surrounding quotes, with empty case handled separately

--- a/BenchmarkVCFs/SimpleBenchmark.wdl
+++ b/BenchmarkVCFs/SimpleBenchmark.wdl
@@ -378,35 +378,35 @@ task BCFToolsStats {
             with open(file_path, 'r') as file:
                 bcf_file = file.readlines()
 
-                # sample-specific stats
-                sn_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'SN\t' in x])), sep='\t')
-                final_sn_df = sn_df.drop(columns=['# SN', '[2]id']).rename(columns={'[3]key': 'Category', '[4]value': 'Count'})[3:]
-                final_sn_df['Category'] = final_sn_df['Category'].apply(lambda x: x.replace('number of ', '').replace(':', ''))
-                idd_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'IDD\t' in x])), sep='\t')
-                final_idd_df = idd_df.drop(columns=['# IDD', '[2]id', '[5]number of genotypes', '[6]mean VAF']).rename(columns={
-                    '[3]length (deletions negative)': 'INDEL_Length', '[4]number of sites': 'Count'
-                })
-                st_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'ST\t' in x])), sep='\t')
-                final_st_df = st_df.drop(columns=['# ST', '[2]id']).rename(columns={'[3]type': 'Substitution', '[4]count': 'Count'})
+            # sample-specific stats
+            sn_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'SN\t' in x])), sep='\t')
+            final_sn_df = sn_df.drop(columns=['# SN', '[2]id']).rename(columns={'[3]key': 'Category', '[4]value': 'Count'})[3:]
+            final_sn_df['Category'] = final_sn_df['Category'].apply(lambda x: x.replace('number of ', '').replace(':', ''))
+            idd_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'IDD\t' in x])), sep='\t')
+            final_idd_df = idd_df.drop(columns=['# IDD', '[2]id', '[5]number of genotypes', '[6]mean VAF']).rename(columns={
+                '[3]length (deletions negative)': 'INDEL_Length', '[4]number of sites': 'Count'
+            })
+            st_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'ST\t' in x])), sep='\t')
+            final_st_df = st_df.drop(columns=['# ST', '[2]id']).rename(columns={'[3]type': 'Substitution', '[4]count': 'Count'})
 
-                # run-specific stats
-                qual_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'QUAL\t' in x])), sep='\t')
-                final_qual_df = qual_df.drop(columns=['# QUAL', '[2]id']).rename(columns={
-                    '[3]Quality': 'QUAL', '[4]number of SNPs': 'SNP_Count', '[5]number of transitions (1st ALT)': 'Ti_Count',
-                    '[6]number of transversions (1st ALT)': 'Tv_Count', '[7]number of indels': 'INDEL_Count'
-                })
-                dp_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'DP\t' in x])), sep='\t')
-                final_dp_df = dp_df.drop(columns=['# DP', '[2]id', '[4]number of genotypes', '[5]fraction of genotypes (%)', '[7]fraction of sites (%)']).rename(columns={
-                    '[3]bin': 'DP', '[6]number of sites': 'Count'
-                })
+            # run-specific stats
+            qual_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'QUAL\t' in x])), sep='\t')
+            final_qual_df = qual_df.drop(columns=['# QUAL', '[2]id']).rename(columns={
+                '[3]Quality': 'QUAL', '[4]number of SNPs': 'SNP_Count', '[5]number of transitions (1st ALT)': 'Ti_Count',
+                '[6]number of transversions (1st ALT)': 'Tv_Count', '[7]number of indels': 'INDEL_Count'
+            })
+            dp_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'DP\t' in x])), sep='\t')
+            final_dp_df = dp_df.drop(columns=['# DP', '[2]id', '[4]number of genotypes', '[5]fraction of genotypes (%)', '[7]fraction of sites (%)']).rename(columns={
+                '[3]bin': 'DP', '[6]number of sites': 'Count'
+            })
 
-                return {
-                    'SN_df': final_sn_df,
-                    'IDD_df': final_idd_df,
-                    'ST_df': final_st_df,
-                    'QUAL_df': final_qual_df,
-                    'DP_df': final_dp_df
-                }
+            return {
+                'SN_df': final_sn_df,
+                'IDD_df': final_idd_df,
+                'ST_df': final_st_df,
+                'QUAL_df': final_qual_df,
+                'DP_df': final_dp_df
+            }
 
         df_dict = {
             "TP_Base" : make_dfs("tp_base_stats.tsv"),

--- a/BenchmarkVCFs/SimpleBenchmark.wdl
+++ b/BenchmarkVCFs/SimpleBenchmark.wdl
@@ -1,0 +1,596 @@
+version 1.0
+
+
+# Object holding all reference files, to ensure all localized in tasks
+struct Reference {
+    File fasta
+    File index
+    File dict
+}
+
+# Object representing expression for subsetting VCFs
+struct VariantSelector {
+    String bcf_label
+    String bcf_selector
+}
+
+# Object representing file with intervals to subset analysis over
+struct Stratifier {
+    String label
+    File? interval
+}
+
+# Main workflow: performs evaluation of call_vcf against base_vcf using vcfeval comparison engine,
+# over different analysis modes.
+workflow SimpleBenchmark {
+    input {
+        # VCF information
+        File base_vcf
+        File base_vcf_index
+        String base_output_sample_name
+        String? base_vcf_sample_name
+
+        File call_vcf
+        File call_vcf_index
+        String call_output_sample_name
+        String? call_vcf_sample_name
+
+        # Reference information
+        File ref_fasta
+        File ref_index
+        File ref_dict
+
+        # Subsetting inputs using intervals
+        Array[File] strat_intervals = []
+        Array[String] strat_labels = []
+        Int interval_padding = 0
+        String subset_gatk_tag = "4.2.3.0"
+
+        # Subsetting inputs using variant properties; Note SNP & INDEL are separated automatically later
+        Array[String] bcf_selectors = []
+        Array[String] bcf_labels = []
+
+        # Evaluation inputs
+        File? evaluation_bed
+        Array[String] score_fields = ["GQ"]
+
+        # Columns to add to output files
+        String? experiment_label
+        String? extra_column
+        String? extra_column_label
+
+        # Null File type -- do NOT assign; Needed until WDL has better support for null File values
+        File? NULL_FILE
+    }
+
+    # Create reference object
+    Reference reference = {"fasta": ref_fasta, "index": ref_index, "dict": ref_dict}
+
+    # Add in default "Whole Genome" empty interval list
+    Array[File] full_strat_intervals = flatten([[""], strat_intervals])
+    Array[String] full_strat_labels = flatten([[""], strat_labels])
+
+    # Make Stratifier objects
+    scatter (strat in zip(full_strat_labels, full_strat_intervals)) {
+        Stratifier stratifier_list = {"label": strat.left, "interval": if strat.right != "" then strat.right else NULL_FILE}
+    }
+
+    # Make VariantSelector objects, with default None, Het, and HomVar types
+    Array[String] default_bcf_selectors =  ["", "GT='het'", "GT='hom'"]
+    Array[String] default_bcf_labels = ["", "Het", "HomVar"]
+    Array[String] full_bcf_selectors = flatten([default_bcf_selectors, bcf_selectors])
+    Array[String] full_bcf_labels = flatten([default_bcf_labels, bcf_labels])
+    scatter (selection in zip(full_bcf_labels, full_bcf_selectors)) {
+        VariantSelector selector_list = {"bcf_label": selection.left, "bcf_selector": selection.right}
+    }
+
+    # Perform analysis over all Stratifiers
+    scatter (stratifier in stratifier_list) {
+        call SubsetVCF as SubsetEval {
+            input:
+                input_vcf=call_vcf,
+                input_vcf_index=call_vcf_index,
+                input_sample_name=call_vcf_sample_name,
+                reference=reference,
+                stratifier=stratifier,
+                interval_padding=interval_padding,
+                gatk_tag=subset_gatk_tag,
+                preemptible=3
+        }
+
+        call SubsetVCF as SubsetTruth {
+            input:
+                input_vcf=base_vcf,
+                input_vcf_index=base_vcf_index,
+                input_sample_name=base_vcf_sample_name,
+                reference=reference,
+                stratifier=stratifier,
+                interval_padding=interval_padding,
+                gatk_tag=subset_gatk_tag,
+                preemptible=3
+        }
+
+        # Run over different score_fields to produce other ROC outputs
+        scatter (score_field in score_fields) {
+            call VCFEval as StandardVCFEval {
+                input:
+                    call_vcf=SubsetEval.output_vcf,
+                    call_vcf_index=SubsetEval.output_vcf_index,
+                    call_output_sample_name=call_output_sample_name,
+                    base_vcf=SubsetTruth.output_vcf,
+                    base_vcf_index=SubsetTruth.output_vcf_index,
+                    base_output_sample_name=base_output_sample_name,
+                    reference=reference,
+                    evaluation_bed=evaluation_bed,
+                    score_field=score_field,
+                    strat_label=stratifier.label,
+                    preemptible=3
+            }
+        }
+
+        scatter (selector in selector_list) {
+            # Use the first outputs for tp_base_vcf, fp_vcf, etc. since these should be the same across all score_fields
+            call BCFToolsStats {
+                input:
+                    tp_base_vcf=StandardVCFEval.tp_base_vcf[0],
+                    tp_base_index=StandardVCFEval.tp_base_index[0],
+                    tp_call_vcf=StandardVCFEval.tp_call_vcf[0],
+                    tp_call_index=StandardVCFEval.tp_call_index[0],
+                    fp_vcf=StandardVCFEval.fp_vcf[0],
+                    fp_index=StandardVCFEval.fp_index[0],
+                    fn_vcf=StandardVCFEval.fn_vcf[0],
+                    fn_index=StandardVCFEval.fn_index[0],
+                    strat_label=select_first([stratifier.label, ""]),
+                    bcf_selector=selector.bcf_selector,
+                    bcf_label=selector.bcf_label,
+                    call_output_sample_name=call_output_sample_name,
+                    base_output_sample_name=base_output_sample_name,
+                    evaluation_bed=evaluation_bed
+            }
+        }
+    }
+
+    call CombineSummaries {
+        input:
+            ROC_summaries=flatten(StandardVCFEval.ROC_summary),
+            SN_summaries=flatten(BCFToolsStats.full_sn),
+            IDD_summaries=flatten(BCFToolsStats.full_idd),
+            ST_summaries=flatten(BCFToolsStats.full_st)
+    }
+
+    output {
+        File simple_summary = CombineSummaries.simple_summary
+        File combined_IDD = CombineSummaries.IDD_combined_summaries
+        File combined_ST = CombineSummaries.ST_combined_summaries
+        File combined_ROC = CombineSummaries.ROC_combined_summaries
+    }
+
+}
+
+task SubsetVCF {
+    input {
+        File input_vcf
+        File input_vcf_index
+        String? input_sample_name
+        Reference reference
+
+        Stratifier stratifier
+        Int interval_padding = 0    # Amount of bases to add around stratification intervals
+
+        String gatk_tag
+        Int? preemptible
+        Int disk_size = 10 + ceil(4.2 * size(input_vcf, "GB") + 2.2 * size(input_vcf_index, "GB") + size(reference.fasta, "GB"))
+        Int cpu = 4
+        Int memory = 16
+    }
+
+    command <<<
+        set -xeuo pipefail
+
+        # Create symlink for VCF & index in case their paths are different, e.g. when using TDR
+        ln -s ~{input_vcf} input.vcf.gz
+        ln -s ~{input_vcf_index} input.vcf.gz.tbi
+
+        # Subset to given sample / loci; Output subsetted VCF
+        # Add variable padding to ensure capture of variants on boundaries downstream
+        # Remove unused alternates to make bcftools stats more accurate on multisample callsets
+        gatk SelectVariants \
+            -V input.vcf.gz \
+            -R ~{reference.fasta} \
+            ~{"-sn " + input_sample_name} \
+            ~{"-L " + stratifier.interval} \
+            ~{"--interval-padding " + interval_padding} \
+            --remove-unused-alternates \
+            -O subset.vcf.gz
+
+    >>>
+
+    runtime{
+        docker: "us.gcr.io/broad-gatk/gatk:" + gatk_tag
+        preemptible: select_first([preemptible, 0])
+        disks: "local-disk " + disk_size + " HDD"
+        bootDiskSizeGb: "16"
+        cpu: cpu
+        memory: memory + " GB"
+    }
+
+    output {
+        File output_vcf = "subset.vcf.gz"
+        File output_vcf_index = "subset.vcf.gz.tbi"
+    }
+}
+
+task VCFEval {
+    input {
+        # Input VCF Files
+        File call_vcf
+        File call_vcf_index
+        String call_output_sample_name
+        File base_vcf
+        File base_vcf_index
+        String base_output_sample_name
+
+        Reference reference
+
+        # Interval File to Subset Analysis on given actual truth data
+        File? evaluation_bed
+
+        # String for VCF field to use as ROC score
+        String score_field
+
+        # Label to add to ROC table outputs
+        String strat_label
+
+        # vcfeval Arguments
+        Boolean passing_only = true
+        Boolean require_matching_genotypes = true
+        Boolean enable_ref_overlap = false
+
+        # Runtime params
+        Int? preemptible
+        Int disk_size = ceil(size(call_vcf, "GB") + size(base_vcf, "GB") + size(reference.fasta, "GB") + size(evaluation_bed, "GB")) + 20
+        Int cpu = 8
+        Int memory = 16
+    }
+
+    command <<<
+        set -xeuo pipefail
+
+        rtg format -o rtg_ref ~{reference.fasta}
+        rtg vcfeval \
+            ~{false="--all-records" true="" passing_only} \
+            ~{false="--squash-ploidy" true="" require_matching_genotypes} \
+            ~{true="--ref-overlap" false="" enable_ref_overlap} \
+            -b ~{base_vcf} \
+            -c ~{call_vcf} \
+            ~{"-e " + evaluation_bed} \
+            --vcf-score-field="~{score_field}" \
+            --output-mode split \
+            --decompose \
+            --roc-subset snp,mnp,indel \
+            -t rtg_ref \
+            -o output_dir \
+
+        python3 << CODE
+        import gzip
+        import pandas as pd
+
+        roc_summary = pd.DataFrame()
+        for Type in ['snp', 'mnp', 'indel']:
+            file_path = f'output_dir/{Type}_roc.tsv.gz'
+            with gzip.open(file_path, 'r') as file:
+                roc = [line.decode('utf-8') for line in file.readlines()]
+            header_names = [line.replace('#', '').replace('\n', '') for line in roc if '#' in line][-1].split('\t')
+            df = pd.read_csv(file_path, sep='\t', comment='#', header=None, names=header_names)
+
+            rename_columns = {'score': 'Score', 'true_positives_baseline': 'TP_Base',
+                  'false_positives': 'FP', 'true_positives_call': 'TP_Call', 'false_negatives': 'FN',
+                  'precision': 'Precision', 'sensitivity': 'Recall', 'f_measure': 'F1_Score'}
+
+            df = df.rename(columns=rename_columns)
+            df['Type'] = Type.upper()
+            df['Stratifier'] = "~{strat_label}"
+            df['Score_Field'] = "~{score_field}"
+            df['Call_Name'] = "~{call_output_sample_name}"
+            df['Base_Name'] = "~{base_output_sample_name}"
+
+            roc_summary = pd.concat([roc_summary, df])
+
+        roc_summary.to_csv('ROC_summary.tsv', sep='\t', index=False)
+
+        CODE
+
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/rtg:v1.0"
+        preemptible: select_first([preemptible, 0])
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory + " GB"
+    }
+
+    output {
+        File ROC_summary = "ROC_summary.tsv"
+
+        File tp_base_vcf = "output_dir/tp-baseline.vcf.gz"
+        File tp_base_index = "output_dir/tp-baseline.vcf.gz.tbi"
+        File tp_call_vcf = "output_dir/tp.vcf.gz"
+        File tp_call_index = "output_dir/tp.vcf.gz.tbi"
+        File fp_vcf = "output_dir/fp.vcf.gz"
+        File fp_index = "output_dir/fp.vcf.gz.tbi"
+        File fn_vcf = "output_dir/fn.vcf.gz"
+        File fn_index = "output_dir/fn.vcf.gz.tbi"
+    }
+}
+
+task BCFToolsStats {
+    input {
+        # Post-vcfeval files
+        File tp_base_vcf
+        File tp_base_index
+        File tp_call_vcf
+        File tp_call_index
+        File fp_vcf
+        File fp_index
+        File fn_vcf
+        File fn_index
+
+        String strat_label
+        String bcf_selector
+        String bcf_label
+
+        String call_output_sample_name
+        String base_output_sample_name
+
+        File? evaluation_bed
+
+        Int disk_size = ceil(size(tp_base_vcf, "GB") + size(tp_call_vcf, "GB") + size(fp_vcf, "GB") + size(fn_vcf, "GB")) + 20
+        Int cpu = 16
+        Int memory = 32
+    }
+
+    Int actual_cpu = if cpu < 4 then 4 else cpu    # Make sure to assign at least 4 CPUs to split across 4 parallel procs
+
+    # Handle parsing bcf_selector with surrounding quotes, with empty case handled separately
+    String selection = if bcf_selector!= "" then "-i " + '"' + bcf_selector + '"' else ""
+
+    command <<<
+        set -xeuo pipefail
+
+        # Subset to evaluation bed if provided, to ensure not too many FNs picked up outside of it
+        bcftools stats ~{selection} -s- ~{"-R" + evaluation_bed} --threads ~{floor(actual_cpu / 4)} ~{tp_base_vcf} > tp_base_stats.tsv &
+        TP_BASE_PID=$!
+        bcftools stats ~{selection} -s- ~{"-R" + evaluation_bed} --threads ~{floor(actual_cpu / 4)} ~{tp_call_vcf} > tp_call_stats.tsv &
+        TP_CALL_PID=$!
+        bcftools stats ~{selection} -s- ~{"-R" + evaluation_bed} --threads ~{floor(actual_cpu / 4)} ~{fp_vcf} > fp_stats.tsv &
+        FP_PID=$!
+        bcftools stats ~{selection} -s- ~{"-R" + evaluation_bed} --threads ~{floor(actual_cpu / 4)} ~{fn_vcf} > fn_stats.tsv
+
+        # Proceed only after all above parallel commands finish
+        wait $TP_BASE_PID
+        wait $TP_CALL_PID
+        wait $FP_PID
+
+
+        python3 << CODE
+        import io
+        import pandas as pd
+
+        def make_dfs(file_path):
+            with open(file_path, 'r') as file:
+                bcf_file = file.readlines()
+
+                # sample-specific stats
+                sn_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'SN\t' in x])), sep='\t')
+                final_sn_df = sn_df.drop(columns=['# SN', '[2]id']).rename(columns={'[3]key': 'Category', '[4]value': 'Count'})[3:]
+                final_sn_df['Category'] = final_sn_df['Category'].apply(lambda x: x.replace('number of ', '').replace(':', ''))
+                idd_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'IDD\t' in x])), sep='\t')
+                final_idd_df = idd_df.drop(columns=['# IDD', '[2]id', '[5]number of genotypes', '[6]mean VAF']).rename(columns={
+                    '[3]length (deletions negative)': 'INDEL_Length', '[4]number of sites': 'Count'
+                })
+                st_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'ST\t' in x])), sep='\t')
+                final_st_df = st_df.drop(columns=['# ST', '[2]id']).rename(columns={'[3]type': 'Substitution', '[4]count': 'Count'})
+
+                # run-specific stats
+                qual_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'QUAL\t' in x])), sep='\t')
+                final_qual_df = qual_df.drop(columns=['# QUAL', '[2]id']).rename(columns={
+                    '[3]Quality': 'QUAL', '[4]number of SNPs': 'SNP_Count', '[5]number of transitions (1st ALT)': 'Ti_Count',
+                    '[6]number of transversions (1st ALT)': 'Tv_Count', '[7]number of indels': 'INDEL_Count'
+                })
+                dp_df = pd.read_csv(io.StringIO('\n'.join([x for x in bcf_file if 'DP\t' in x])), sep='\t')
+                final_dp_df = dp_df.drop(columns=['# DP', '[2]id', '[4]number of genotypes', '[5]fraction of genotypes (%)', '[7]fraction of sites (%)']).rename(columns={
+                    '[3]bin': 'DP', '[6]number of sites': 'Count'
+                })
+
+                return {
+                    'SN_df': final_sn_df,
+                    'IDD_df': final_idd_df,
+                    'ST_df': final_st_df,
+                    'QUAL_df': final_qual_df,
+                    'DP_df': final_dp_df
+                }
+
+        df_dict = {
+            "TP_Base" : make_dfs("tp_base_stats.tsv"),
+            "TP_Call": make_dfs("tp_call_stats.tsv"),
+            "FP": make_dfs("fp_stats.tsv"),
+            "FN": make_dfs("fn_stats.tsv")
+        }
+
+        # Make full SN (Summary Numbers) df
+        full_sn_df = pd.DataFrame({'Category': df_dict['TP_Base']['SN_df']['Category']})
+        for stat in df_dict:
+            full_sn_df = df_dict[stat]['SN_df'].rename(columns={'Count': f'{stat}_Count'}).merge(full_sn_df, on='Category', how='outer')
+        full_sn_df.fillna(0)
+        full_sn_df['Call_Name'] = "~{call_output_sample_name}"
+        full_sn_df['Base_Name'] = "~{base_output_sample_name}"
+        full_sn_df['Stratifier'] = "~{strat_label}"
+        full_sn_df['BCF_Label'] = "~{bcf_label}"
+
+        # Make full IDD (InDel Distribution) df
+        full_idd_df = pd.DataFrame({'INDEL_Length': df_dict['TP_Base']['IDD_df']['INDEL_Length']})
+        for stat in df_dict:
+            full_idd_df = df_dict[stat]['IDD_df'].rename(columns={'Count': f'{stat}_Count'}).merge(full_idd_df, on='INDEL_Length', how='outer')
+        full_idd_df.fillna(0)
+        full_idd_df['Call_Name'] = "~{call_output_sample_name}"
+        full_idd_df['Base_Name'] = "~{base_output_sample_name}"
+        full_idd_df['Stratifier'] = "~{strat_label}"
+        full_idd_df['BCF_Label'] = "~{bcf_label}"
+
+        # Make full ST (Substitution) df
+        full_st_df = pd.DataFrame({'Substitution': df_dict['TP_Base']['ST_df']['Substitution']})
+        for stat in df_dict:
+            full_st_df = df_dict[stat]['ST_df'].rename(columns={'Count': f'{stat}_Count'}).merge(full_st_df, on='Substitution', how='outer')
+        full_st_df = full_st_df.fillna(0)
+        full_st_df['Call_Name'] = "~{call_output_sample_name}"
+        full_st_df['Base_Name'] = "~{base_output_sample_name}"
+        full_st_df['Stratifier'] = "~{strat_label}"
+        full_st_df['BCF_Label'] = "~{bcf_label}"
+
+
+        # Write files
+        full_sn_df.to_csv('Full_SN.tsv', sep='\t', index=False)
+        full_idd_df.to_csv('Full_IDD.tsv', sep='\t', index=False)
+        full_st_df.to_csv('Full_ST.tsv', sep='\t', index=False)
+
+        CODE
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/bcftools:v1.0"
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: actual_cpu
+        memory: memory + "GB"
+    }
+
+    output {
+        File full_sn = "Full_SN.tsv"
+        File full_idd = "Full_IDD.tsv"
+        File full_st = "Full_ST.tsv"
+    }
+}
+
+task CombineSummaries {
+    input {
+        Array[File] ROC_summaries
+
+        Array[File] SN_summaries
+        Array[File] IDD_summaries
+        Array[File] ST_summaries
+
+        String? experiment_label
+        String? extra_column
+        String? extra_column_label
+
+        Int disk_size = 50
+        Int cpu = 2
+        Int memory = 8
+    }
+
+    command <<<
+        set -xeuo pipefail
+
+        python << CODE
+        import pandas as pd
+
+        # Concat all ROC summaries into one file
+        full_ROC = pd.DataFrame()
+        for file in ["~{default="" sep="\", \"" ROC_summaries}"]:
+            df = pd.read_csv(file, sep='\t')
+            full_ROC = pd.concat([full_ROC, df])
+
+        if "~{experiment_label}" != "":
+            full_ROC['Experiment'] = "~{experiment_label}"
+
+        if ("~{extra_column}" != "") & ("~{extra_column_label}" != ""):
+            full_ROC["~{extra_column}"] = "~{extra_column_label}"
+
+        full_ROC.to_csv('Full_ROC.tsv', sep='\t', index=False)
+
+        # Gather all tables for bcftools stats outputs
+        full_SN = pd.DataFrame()
+        for file in ["~{default="" sep="\", \"" SN_summaries}"]:
+            df = pd.read_csv(file, sep='\t')
+            full_SN = pd.concat([full_SN, df])
+
+        full_IDD = pd.DataFrame()
+        for file in ["~{default="" sep="\", \"" IDD_summaries}"]:
+            df = pd.read_csv(file, sep='\t')
+            full_IDD = pd.concat([full_IDD, df])
+
+        full_ST = pd.DataFrame()
+        for file in ["~{default="" sep="\", \"" ST_summaries}"]:
+            df = pd.read_csv(file, sep='\t')
+            full_ST = pd.concat([full_ST, df])
+
+        # Label INDEL types
+        full_IDD['INDEL_Type'] = full_IDD['INDEL_Length'].apply(lambda x: 'Ins' if x > 0 else 'Del')
+        full_IDD['Type'] = full_IDD['BCF_Label'].fillna("") + 'INDEL'
+        full_IDD = full_IDD.drop(columns=['BCF_Label'])
+
+        # Label SNP sub types
+        def ti_tv(sub):
+            if (set(sub.split('>')) == {'A', 'G'}) or (set(sub.split('>')) == {'C', 'T'}):
+                return 'Ti'
+            else:
+                return 'Tv'
+
+        full_ST['Substitution_Type'] = full_ST['Substitution'].apply(ti_tv)
+        full_ST['Type'] = full_ST['BCF_Label'].fillna("") + 'SNP'
+        full_ST = full_ST.drop(columns=['BCF_Label'])
+
+        # Clean up for simple summary
+        simple_renaming = {'SNPs': 'SNP', 'MNPs': 'MNP', 'indels': 'INDEL', 'others': 'Other', 'multiallelic sites': 'MA', 'multiallelic SNP sites': 'MASNP'}
+        simple_summary = full_SN.copy()
+        simple_summary['Category'] = simple_summary['Category'].replace(simple_renaming)
+        simple_summary['Type'] = simple_summary['BCF_Label'].fillna("") + simple_summary['Category']
+        simple_summary = simple_summary.drop(columns=['BCF_Label', 'Category'])
+
+        # Compute simple stats
+        for df in [full_SN, full_IDD, full_ST, simple_summary]:
+            df.columns = [c.replace('_Count', '') for c in df.columns]
+            df['Precision'] = df['TP_Call'] / (df['TP_Call'] + df['FP'])
+            df['Recall'] = df['TP_Base'] / (df['TP_Base'] + df['FN'])
+            df['F1_Score'] = 2 * df['Precision'] * df['Recall'] / (df['Precision'] + df['Recall'])
+
+        # Add optional labels
+        for df in [full_SN, full_IDD, full_ST, simple_summary]:
+            if "~{experiment_label}" != "":
+                df['Experiment'] = "~{experiment_label}"
+
+            if ("~{extra_column}" != "") & ("~{extra_column_label}" != ""):
+                df["~{extra_column}"] = "~{extra_column_label}"
+
+        # Reorder columns
+        metadata_cols = ['Call_Name', 'Base_Name', 'Stratifier', 'Type']
+        metadata_cols = metadata_cols + ["~{extra_column}"] if "~{extra_column}" != "" else metadata_cols
+        metadata_cols = ['Experiment'] + metadata_cols if "~{experiment_label}" != "" else metadata_cols
+        stat_cols = ['TP_Call', 'TP_Base', 'FP', 'FN', 'Precision', 'Recall', 'F1_Score']
+
+        full_IDD = full_IDD[metadata_cols + ['INDEL_Type', 'INDEL_Length'] + stat_cols]
+        full_ST = full_ST[metadata_cols + ['Substitution', 'Substitution_Type'] + stat_cols]
+        simple_summary = simple_summary[metadata_cols + stat_cols]
+
+        # Skip returning full_SN since it is redundant with simple_summary
+        simple_summary.to_csv('SimpleSummary.tsv', sep='\t', index=False)
+        full_IDD.to_csv('Full_IDD.tsv', sep='\t', index=False)
+        full_ST.to_csv('Full_ST.tsv', sep='\t', index=False)
+
+        CODE
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory + "GB"
+    }
+
+    output {
+        File simple_summary = "SimpleSummary.tsv"
+        File IDD_combined_summaries = "Full_IDD.tsv"
+        File ST_combined_summaries = "Full_ST.tsv"
+        File ROC_combined_summaries = "Full_ROC.tsv"
+    }
+}

--- a/BenchmarkVCFs/SimpleBenchmark.wdl
+++ b/BenchmarkVCFs/SimpleBenchmark.wdl
@@ -251,7 +251,7 @@ task VCFEval {
         # vcfeval Arguments
         Boolean passing_only = true
         Boolean require_matching_genotypes = true
-        Boolean enable_ref_overlap = false
+        Boolean enable_ref_overlap = true
 
         # Runtime params
         Int? preemptible

--- a/BenchmarkVCFs/SimpleBenchmark.wdl
+++ b/BenchmarkVCFs/SimpleBenchmark.wdl
@@ -158,7 +158,11 @@ workflow SimpleBenchmark {
             ROC_summaries=flatten(StandardVCFEval.ROC_summary),
             SN_summaries=flatten(BCFToolsStats.full_sn),
             IDD_summaries=flatten(BCFToolsStats.full_idd),
-            ST_summaries=flatten(BCFToolsStats.full_st)
+            ST_summaries=flatten(BCFToolsStats.full_st),
+            experiment_label=experiment_label,
+            extra_column=extra_column,
+            extra_column_label=extra_column_label
+
     }
 
     output {

--- a/BenchmarkVCFs/SimpleBenchmark.wdl
+++ b/BenchmarkVCFs/SimpleBenchmark.wdl
@@ -286,8 +286,8 @@ task VCFEval {
         roc_summary = pd.DataFrame()
         for Type in ['snp', 'mnp', 'indel']:
             file_path = f'output_dir/{Type}_roc.tsv.gz'
-            with gzip.open(file_path, 'r') as file:
-                roc = [line.decode('utf-8') for line in file.readlines()]
+            with gzip.open(file_path, 'rt') as file:
+                roc = [line for line in file.readlines()]
             header_names = [line.replace('#', '').replace('\n', '') for line in roc if '#' in line][-1].split('\t')
             df = pd.read_csv(file_path, sep='\t', comment='#', header=None, names=header_names)
 

--- a/BenchmarkVCFs/SimpleBenchmark.wdl
+++ b/BenchmarkVCFs/SimpleBenchmark.wdl
@@ -248,7 +248,7 @@ task VCFEval {
 
         # Runtime params
         Int? preemptible
-        Int disk_size = ceil(size(call_vcf, "GB") + size(base_vcf, "GB") + size(reference.fasta, "GB") + size(evaluation_bed, "GB")) + 20
+        Int disk_size = ceil(size(call_vcf, "GB") + size(base_vcf, "GB") + size(reference.fasta, "GB")) + 25
         Int cpu = 8
         Int memory = 16
     }

--- a/BenchmarkVCFs/SimpleBenchmark.wdl
+++ b/BenchmarkVCFs/SimpleBenchmark.wdl
@@ -290,7 +290,6 @@ task VCFEval {
             header_lines = []
             # Read through file lines until hitting one without leading '#'
             with gzip.open(file_path, 'rt') as file:
-                roc = [line for line in file.readlines()]
                 for line in file:
                     if line[0] == '#':
                         header_lines += [line]

--- a/BenchmarkVCFs/SimpleBenchmark_README.md
+++ b/BenchmarkVCFs/SimpleBenchmark_README.md
@@ -1,0 +1,282 @@
+# SimpleBenchmark Guide
+
+This guide describes an overview of the [SimpleBenchmark](SimpleBenchmark.wdl) WDL used for evaluating VCF performance 
+against a known baseline. This includes how to toggle inputs for different goals, a description of the code structure, 
+and comparison with previously developed tools.
+
+Some useful resources referenced below:
+* `bcftools` [Filtering Expressions](https://samtools.github.io/bcftools/bcftools.html#expressions)
+* [RTG manual](https://cdn.jsdelivr.net/gh/RealTimeGenomics/rtg-core@master/installer/resources/core/RTGOperationsManual.pdf), 
+particularly the section on `vcfeval`
+
+---
+
+## Acknowledgements
+
+This tool was heavily inspired by the [BenchmarkVCFs](https://github.com/broadinstitute/palantir-workflows/blob/main/BenchmarkVCFs/BenchmarkVCFs.wdl) 
+and [FindSamplesAndBenchmark](https://github.com/broadinstitute/palantir-workflows/blob/main/BenchmarkVCFs/FindSamplesAndBenchmark.wdl) tools, 
+with some code lifted directly or slightly modified from both. Although this tool is mainly meant to supersede BenchmarkVCFs in most use cases, 
+there are a small number of changes to the outputs which are summarized at the end of this article that old users will have to 
+adapt to before sticking it into their pipelines.
+
+---
+
+## Table of Contents
+
+1. [Usage](#usage)
+    1. [Inputs](#inputs)
+    2. [Interpreting Output Data](#interpreting-output-data)
+        1. [Some Warnings on Interpreting Output Statistics](#some-warnings-on-interpreting-output-statistics)
+2. [Structure of the Workflow](#structure-of-the-workflow)
+    1. [Subset](#subset)
+    2. [Classify Variants](#classify-variants)
+    3. [Compute Statistics](#compute-statistics)
+    4. [Combine Statistics](#combine-statistics)
+3. [Comparison With BenchmarkVCFs](#comparison-with-benchmarkvcfs)
+
+---
+
+## Usage
+
+### Inputs
+
+The following are the top-level inputs for the workflow. We borrow the `vcfeval` terminology in referring to the paradigm 
+of a "base"line VCF and a "call"set VCF benchmarked against it.
+
+* `base_vcf` - the VCF to use as baseline.
+* `base_vcf_index` - the index of the VCF to use as baseline.
+* `base_output_sample_name` - the name to appear in output data to label the baseline sample.
+* `base_vcf_sample_name` - (optional) the name appearing in the VCF to label this sample; to be used only for extracting that sample 
+from a multisample callset. **Tip**: If you expect to use the same baseline repeatedly, consider extracting it from a 
+multisample callset once, and then use that as input here to save time repeatedly subsetting a large VCF.
+
+* `call_vcf` - the VCF ("callset") to be evaluated.
+* `call_vcf_index` - the index of the VCF to be evaluated.
+* `call_output_sample_name` - the name to appear in output data to label the evaluated sample.
+* `call_vcf_sample_name` - (optional) the name appearing in the VCF to label this sample; to be used only for extracting that sample 
+from a multisample callset.
+
+* `ref_fasta` - reference fasta file matching the input VCFs.
+* `ref_index` - reference fasta index.
+* `ref_dict` - reference dictionary.
+
+* `strat_intervals` - (default = `[]`) list of interval files to stratify by to compute benchmarking statistics over. 
+These can be any of the allowed interval file formats supported by GATK, including bed and Picard interval_list files. 
+**Regardless of input, an "empty" interval file will be added to perform benchmarking over without any subseting, which 
+will have a corresponding empty label.** This is important when computing summary statistics in groups, since some programs 
+(like pandas groupby) default to excluding entries with null values. The naming convention for the empty file is left empty 
+to avoid collisions with user input names on other interval files.
+* `strat_labels` - (default = `[]`) list of names for the given `strat_intervals`. The order must match, and the sizes must agree.
+* `interval_padding` - (default = 0) an integer number of bases to pad the given `strat_intervals` by when subsetting. 
+Useful for toggling to see how much statistics change when adding more bases, to help control for variants occuring near 
+the boundaries of given intervals.
+* `subset_gatk_tag` - (default = "4.2.3.0") a (string) version to use for GATK when performing subsetting.
+
+* `bcf_selectors` - (default = `[]`) list of strings representing bcftools filtering expressions (see reference above). 
+For each provided, `bcftools stats` will be run using the filter expression and counting TP, FP, etc. on the resulting 
+subset of variants. Note that the selectors `["", "GT='het'", "GT='hom'"]` will be appended to your inputs to cover the 
+default cases of no selection, Het variants, and HomVar variants respectively (with labels "", "Het", and "HomVar" respectively). 
+Note also that SNP and INDEL statistics are automatically computed separately in the workflow, so there's no need to split 
+them in your expressions. **WARNING**: Despite the examples in the `bcftools` documentation, you must follow the default 
+formatting and use double quotes around the WDL string, with single quotes around internal expressions when appropriate.
+* `bcf_labels` - (default = `[]`) a list of labels to match the input `bcf_selectors` list, to appear next to statistics 
+computed on the corresponding subset in the output data tables.
+
+* `evaluation_bed` - if provided, only variants inside this bed file will be counted in statistics. Note this is slightly 
+different than using a `strat_interval` because `vcfeval` will process variants on the boundary slightly differently here 
+(see the RTG manual for details). This is intended to be used when one has a "high confidence" region for known truth samples. 
+**This must be a bed file!**
+* `score_fields` - (default = `["GQ"]`) an optional list of fields to use for stratifying ROC data. For each entry, the 
+`vcfeval` will be run to produce the proper ROC data with the given string input to `--vcf-score-field`. Example values 
+include `"GQ"`, `INFO.<NAME>`, and `FORMAT.<NAME>`. **WARNING**: Some values might not make sense to stratify when 
+interested in *both* precision and recall statistics. For example, with the value `FORMAT.DP` it might make sense to 
+evaluate precision of calls made by depth in the callset, but often the baseline/truth doesn't have any intrinsic DP 
+associated with each variant, and so any present in the baseline may lead to misleading recall statistics. See the 
+section on [Interpreting Output Data](#interpreting-output-data) below for details.
+
+* `experiment_label` - an optional string to populate "Experiment" column in final output tables. Useful for incorporating 
+Terra table information about experimental groups to do grouped analyses downstream, or for easier integration into provided 
+visualizer tools.
+* `extra_column` - an optional string title for an additional column to add to final output tables, for downstream analysis.
+* `extra_column_label` - values to populate in the optional `extra_column`, if specified. To make downstream analysis easier 
+by incorporating Terra table information, e.g. `MEAN_COVERAGE`.
+
+* `NULL_FILE` - do NOT overwrite. This input exists for technical reasons due to WDL lacking good handling for null File 
+types in its current version.
+
+In addition, there are some `vcfeval` options that can be toggled using the Boolean inputs `require_matching_genotypes`, 
+`enable_ref_overlap`, and `passing_only`. Check the RTG manual for more details on how these can affect output. For most users, 
+these can be safely left as default.
+
+Each task also has inputs to control the amount of disk, CPU, and memory allocated. These can be toggled to optimize 
+performance on different inputs.
+
+
+### Interpreting Output Data
+
+There are four files output by the workflow. They are:
+
+* `simple_summary` - This file is approximately the same as the usual outputs from the old benchmarking script. It contains 
+counts of the usual TP, FP, etc. statistics, along with computed Precision, Recall, and F1_Score stats.
+* `combined_IDD` - (InDel Distribution) This file contains distributions of the TP, FP, etc. statistics by length of INDEL, 
+where negative values correspond to deletions. For convenience, the column `INDEL_Type` labels the variant class as `Ins` or 
+`Del` accordingly, so users can readily group and process their own statistics per class.
+* `combined_ST` - (Substitution Types) This file contains distributions of the TP, FP, etc. statistics by SNP substitution 
+(e.g. `A>C`, `A>G`, etc.). For convenience, the column `Substitution_Type` labels the variant class as `Ti` or `Tv` depending 
+on if the substitution is a Transition or Transversion accordinly, so users can readily group and process their own 
+statistics per class.
+* `combined_ROC` - This file is a concatenation of all of the ROC outputs by `vcfeval`, with labels to separate out the 
+stratifiers, variant types, etc. A `score_field` column records the user input score label for the given row.
+
+We follow the same convention as RTG when computing Precision / Recall statistics, namely we use:
+
+$$ Prec = \frac{TP_{call}}{(TP_{call} + FP)}, $$
+
+$$ Recall = \frac{TP_{base}}{(TP_{base} + FN)}, $$
+
+and
+
+$$ F_1 = 2 \cdot \frac{Prec \cdot Recall}{Prec + Recall}.$$
+
+#### Some Warnings on Interpreting Output Statistics
+
+Although there is a lot of possible functionality afforded by the extensive input options above, one should be careful about 
+interpreting the results in some cases. We provide a few examples here as warnings against turning a bunch of options on and 
+focusing on statistics that may end up being misleading if not carefully analyzed, which is inherent to the benchmarking process.
+
+##### 1. Subsetting regions can cause greater FPs/FNs.
+
+Due to differences in representing equivalent variants, it's possible that subsetting can lead to false classification of 
+variants as mistakes when they should be considered TPs. Suppose there is a variant $A$ in position $X$ in the call VCF, 
+and a variant $B$ in position $X+Y$ in the base VCF. Normally, `vcfeval` will resolve the underlying haplotypes to compare 
+if these produce equivalent sequences. However, if your input intervals mandate including only those variants at a position 
+less/greater than somewhere between $X$ and $X+Y$, then only one of these variants will be visible during the `vcfeval` 
+processing, and you won't get matching haplotypes (when normally you should).
+
+To mitigate this, the `interval_padding` input is a dial that can be turned to see how variants near the boundaries of 
+your interval files may be influencing the end statistics. Seeing large jumps when toggling this might be indicative of 
+lots of action on the edges, and you might consider changing your interval files (or doing away with them altogether, and 
+only using the `evaluation_bed` input which doesn't subset, but performs other advanced counting).
+
+##### 2. Using ROC scores / variant selectors that are asymmetric can be misleading.
+
+The inputs allowed for stratifying ROC scores and subsetting variant types with `bcftools` filtering selectors is extremely 
+flexible, but this comes at the risk of producing statistics that may not make sense if not done carefully. Here's a good 
+example to keep in mind when thinking about if your data might be susceptible to this.
+
+Suppose you have a call VCF you'd like to benchmark against some "truth" base VCF. You want to understand how the depth 
+(DP) of your callset correlates with better accuracy in the variants it calls. You put "DP" in as a `score_field`, and 
+produce some ROC outputs. In this case, the Recall statistics output would not be useful, because "truth" VCFs are often 
+produced using very large coverage. Because DP is not "intrinsic" to the variants themselves, but rather to the sequencing 
+process, there's no canonical way to measure to what extent you accurately "recall" variants above a given DP threshold. 
+The precision statistics, however, make sense to interpret above given DP thresholds in the call VCF because they are 
+derived from TP and FP alone, which are labeled based on the call variants. In this way, you can track how accuracy 
+(hopefully) improves when increasing DP in the calls, but should ignore the DP values in the base VCF.
+
+On the other hand, consider another situation where it makes sense to subset by variant type, when the situation is 
+sequencing-independent and more symmetric. Suppose you have a variant annotation that labels SNPs occuring inside 
+reference homopolymers by the length of the homopolymer. Because this only depends on the reference, this is a much 
+safer variant selector to subset on (maybe by setting some thresholds using the `bcftools` expression language) because 
+variants occuring in either the call or base VCF should be on equal footing.
+
+Note in the case that a ROC score field exists in the call VCF but not the base, you can still get ROC statistics output 
+from `vcfeval`. See the RTG manual for details on how it interpolates values for the base along the different thresholds.
+
+---
+
+## Structure of the Workflow
+
+The workflow has the following main high-level tasks:
+
+1. **Subset** the pair of VCFs given to each interval file provided.
+2. **Classify Variants** in both VCFs for each subsetted pair using `vcfeval`.
+3. **Compute Statistics** on labeled variants in different subsets of types of variants.
+4. **Combine Statistics** into a few final files for output.
+
+Some details are provided for each step below.
+
+### Subset
+
+For each provided interval file, we use `gatk SelectVariants` to subset the provided VCFs. An optional padding amount 
+can be provided to help control for a potential large number of variants on the boundaries. This always includes a special 
+case where no subsetting is performed for "genone-wide" performance to be captured alongside the subsets provided. If a 
+multisample VCF is provided, users must specify the sample name of the desired sample to proceed to compare in the next 
+steps. Extraction of that sample is performed during this step.
+
+### Classify Variants
+
+For each subsetted pair from the last step, we run `vcfeval` to perform haplotype-aware variant comparison. This is a 
+sophisticated way to comparing variants across VCFs which accounts for potentially different methods of representing 
+haplotype-equivalent variants. Each variant in the files can be categorized as true positive (TP), false positive (FP), 
+and false negative (FN) based on how the call variants compare with the base. The command outputs four VCF files containing 
+each of these cateogies (treating TPs in call as possibly different from TPs in base) which then get passed to downstream 
+analysis tools.
+
+In addition, the command outputs ROC-style statistics split by user-input score fields (e.g. stratify TP, FP, FN counts 
+by GQ scores, etc.). Users are allowed to specify a list of such score fields (e.g. GQ, QUAL, etc.) and the workflow 
+will create ROC files for each. Some data cleaning is performed in this step on the ROC files output by `vcfeval`.
+
+### Compute Statistics
+
+In this step, we take the VCF subsets of TPs, FPs, and FNs and run `bcftools stats` on them to collect an array of 
+statistics, particularly the count of SNPs and INDELs in each of these categories. This is performed once for each user-input 
+variant selector, which must be communicated using the `bcftools` expressive filtering language. A large amount of data 
+cleaning is also done in this step on the outputs to prepare for them to be compiled into the final outputs later.
+
+### Combine Statistics
+
+This step collects all of the statistics files generated previously over the different interval files and variant selector 
+conditions and combines them into one large file. Each row will contain unique identifiers to explain the interval file 
+subsetted to and any variant selector conditions used, along with user-provided input sample names, so that users can 
+safely concatenate outputs across different runs of the workflow for multi-sample evaluation analysis. There is also a 
+little bit more cleaning to create a "simple summary" output, which is reported alongside the more indepth statistics 
+collected before.
+
+---
+
+## Comparison with BenchmarkVCFs
+
+Although this tool was designed to be an improvement to the BenchmarkVCFs workflow, there are a few key differences that 
+are important both for usage and functionality, which are briefly summarized below for users familiar with the old tool. 
+In other words, this a quick guide for porting over inputs / workflows depending on BenchmarkVCFs to use this workflow instead.
+
+### Output Differences
+* The new `simple_summary` output is meant to closely mimic the `summary` output of BenchmarkVCFs. The key differences are:
+    * The new file is a tsv while the old file is a csv.
+    * The new file uses `TP_Call` in place of `TP_Eval` in the column names. In addition, the new file swaps `Call_Name` 
+for `Name` and `Base_Name` for `Truth_Set`.
+    * A few columns from the old file have been completely dropped. These are:
+        * `Comparison_Engine` - the new tool only supports using `vcfeval` to compare VCFs.
+        * `IndelLength` - users looking to break down statistics by INDEL length are encouraged to use the new `combined_IDD` output.
+        * `IGV_Session` - to save some time, this feature of adding IGV session links has been dropped. This may be added back as an option in the future.
+        * `Summary_Type` - this always output `summary` for a value, except in some INDEL stat cases. Because INDEL stratifying is handled by a new separate output, this column was dropped.
+        * `UNK` - this previously counted variants outside of your evaluation region. Because this can be inferred from the other statistics reported, this was dropped to save time.
+    * Some new default variant categories are included in the new summary, whose counts are computed for free by `bcftools stats`. 
+Note when a site has multiple variants (e.g. a SNP and an INDEL), it increments both counters. These are:
+        * MNPs
+        * Other
+        * MA (multiallelic sites)
+        * MASNP (multiallelic SNP sites)
+    * Subsetting by variant type is now handled by `bcf_selectors` using the `bcftools` filtering expression language, as opposed to GATK jexl expressions (which also did not work properly in the previous WDL in many circumstances).
+    * Subsetting by interval files no longer automatically includes subsetting on their complements. Because many interval 
+  files are specialized, there is major overlap in their complements and often not as much interpretability. Instead, users are 
+  encouraged to create complements of their interval files using any tools available when this data is desired, and then include 
+  them on equal footing with the other interval input files.
+    * The default `bcf_selectors` automatically result in breakdowns by all vs Het vs Hom sites. The data processing is 
+  handled so the `bcf_labels` are concatenated in front of the SNP / INDEL / etc labels, so you still get Type categories like 
+  "HetSNP", etc. In particular, this means e.g. that the old `HetIndel` becomes `HetINDEL` in the new version.
+    * If you run the old and new tools on the same inputs, you might notice some very small changes in the output statistics. 
+  There are few factors here. One is that the old workflow is using an older version of RTG, and some changes to `vcfeval` 
+  have been made since then which get reflected in slightly different stats. Another, more important difference is that 
+  `bcftools` is used to generate a number of the statistics, which may calculate variants slightly differently than the 
+  old tools. (E.g. Try counting the number of SNPs in a VCF using `gatk`, `bcftools`, and `rtg`, and you'll often get slightly 
+  different numbers.) If you notice a large divergence in the final statistics, in particular enough to cause differences in scientific conclusions, please open an [issue](https://github.com/broadinstitute/palantir-workflows/issues).
+* There are three new file outputs which help give granular statistics, taking into account INDEL length distribution, types of SNPs, etc. You can learn more about these in the [Usage](#usage) section.
+
+### Internal Differences
+* The number of tasks run in a typical run of the new workflow should be much lower than the old. This should translate to a significant decrease in 
+runtimes, though that can vary with cloud weather.
+* The old `CrosscheckFingerprints` task (`MatchEvalTruth`) in the BenchmarkVCFs workflow has been removed for now. Any good 
+benchmarking workflow should include a fingerprint check at some step, but it wasn't clear if that should be included in *this* WDL, 
+or a wrapper analogous to FindSamplesAndBenchmark, which has to run fingerprinting to pair up samples regardless. It is likely 
+this will be added back as an (optional, but highly recommended) step in this WDL in the future.

--- a/BenchmarkVCFs/SimpleBenchmark_README.md
+++ b/BenchmarkVCFs/SimpleBenchmark_README.md
@@ -88,17 +88,18 @@ different than using a `strat_interval` because `vcfeval` will process variants 
 **This must be a bed file!**
 * `score_fields` - (default = `["GQ"]`) an optional list of fields to use for stratifying ROC data. For each entry, the 
 `vcfeval` will be run to produce the proper ROC data with the given string input to `--vcf-score-field`. Example values 
-include `"GQ"`, `INFO.<NAME>`, and `FORMAT.<NAME>`. **WARNING**: Some values might not make sense to stratify when 
+include `"GQ"`, `INFO.<NAME>`, and `FORMAT.<NAME>`. See the `vcfeval` documentation for more information 
+**WARNING**: Some values might not make sense to stratify when 
 interested in *both* precision and recall statistics. For example, with the value `FORMAT.DP` it might make sense to 
 evaluate precision of calls made by depth in the callset, but often the baseline/truth doesn't have any intrinsic DP 
 associated with each variant, and so any present in the baseline may lead to misleading recall statistics. See the 
 section on [Interpreting Output Data](#interpreting-output-data) below for details.
 
-* `experiment_label` - an optional string to populate "Experiment" column in final output tables. Useful for incorporating 
+* `experiment_value` - an optional string to populate "Experiment" column in final output tables. Useful for incorporating 
 Terra table information about experimental groups to do grouped analyses downstream, or for easier integration into provided 
 visualizer tools.
-* `extra_column` - an optional string title for an additional column to add to final output tables, for downstream analysis.
-* `extra_column_label` - values to populate in the optional `extra_column`, if specified. To make downstream analysis easier 
+* `extra_column_name` - an optional string title for an additional column to add to final output tables, for downstream analysis.
+* `extra_column_value` - values to populate in the optional `extra_column`, if specified. To make downstream analysis easier 
 by incorporating Terra table information, e.g. `MEAN_COVERAGE`.
 
 * `NULL_FILE` - do NOT overwrite. This input exists for technical reasons due to WDL lacking good handling for null File 

--- a/Utilities/Dockers/BCFTools/Dockerfile
+++ b/Utilities/Dockers/BCFTools/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:22.10
+RUN apt update
+RUN apt install -y git python3 python3-pip wget libbz2-dev liblzma-dev libcurl4-openssl-dev
+
+RUN pip install pandas
+
+# Make bcftools
+RUN wget https://github.com/samtools/bcftools/releases/download/1.16/bcftools-1.16.tar.bz2
+RUN tar -xvf bcftools-1.16.tar.bz2
+WORKDIR bcftools-1.16
+RUN ./configure
+RUN make
+RUN make install
+RUN export PATH=/bcftools-1.16/bcftools:$PATH

--- a/Utilities/Dockers/README.md
+++ b/Utilities/Dockers/README.md
@@ -1,6 +1,24 @@
 # Docker Files
 
-This directory contains `dockerimage` files and descriptions of what each is intended for. 
+This directory contains `dockerimage` files and descriptions of what each is intended for. Here is a description of how
+the fields are populated:
+* Directory: where to find the Dockerfile, under `palantir-workflows/Utilities/Dockers/`.
+* Description: description of the packages installed on the docker.
+* Location: where a pre-built copy of the docker is stored.
+* Used By: links to all WDLs in this repo which use this docker.
+* Usage: command line notation for accessing primary installed packages within the docker.
+* Version Notes: notes on which versions of major packages are installed on the image.
+
+## bcftools
+
+* Directory: BCFTools
+* Description: A docker image containing an installation of [bcftools](https://samtools.github.io/bcftools/bcftools.html).
+Also includes some minimal Python tools (pandas) for data processing.
+* Location: `us.gcr.io/broad-dsde-methods/bcftools:v1.0`
+* Used By: [SimpleBenchmark](../../BenchmarkVCFs/SimpleBenchmark.wdl)
+* Usage: `bcftools [COMMAND]`
+* Version Notes:
+  * 1.0: Versions are `bcftools` 1.16
 
 ## python-data-slim
 
@@ -11,6 +29,7 @@ with the libraries `pandas`, `numpy`, `scipy`, `firecloud`, `fsspec` (a `fireclo
 * Location: `us.gcr.io/broad-dsde-methods/python-data-slim`
 * Used By: [FindSamplesAndBenchmark](../../BenchmarkVCFs/FindSamplesAndBenchmark.wdl), 
   [CollectBenchmarkSucceeded](../WDLs/CollectBenchmarkSucceeded.wdl)
+* Usage: `python <<CODE [CODE HERE] CODE`
 * Version Notes: 
     * 1.0: Versions are `python3` 3.9.9, `pandas` 1.3.4, `numpy` 1.21.4, `scipy` 1.7.2, `firecloud` 0.16.32, 
     `fsspec` 2022.7.1, `gcsfs` 2022.7.1.
@@ -23,3 +42,15 @@ with the libraries `pandas`, `numpy`, `scipy`, `firecloud`, `fsspec` (a `fireclo
 * Used By: [FunctionalEquivalence](../../FunctionalEquivalence/FunctionalEquivalence.wdl)
 * Version Notes: 
     * 1.0: Versions are `matplotlib` 3.5.3, `plotly` 5.10.0.
+    
+## rtg
+
+* Directory: RTG
+* Description: A docker image containing an installation of [RTG Tools](https://github.com/RealTimeGenomics/rtg-tools). 
+In particular, this includes `vcfeval`, and all their other VCF manipulation tools. Also comes with Python (pandas) for
+convenient data manipulation tools.
+* Location: `us.gcr.io/broad-dsde-methods/rtg:v1.0`
+* Used By: [SimpleBenchmark](../../BenchmarkVCFs/SimpleBenchmark.wdl)
+* Usage: `rtg [COMMAND]`
+* Version Notes: 
+  * 1.0: Versions are `rtg` 3.12.1

--- a/Utilities/Dockers/README.md
+++ b/Utilities/Dockers/README.md
@@ -31,8 +31,8 @@ with the libraries `pandas`, `numpy`, `scipy`, `firecloud`, `fsspec` (a `fireclo
   [CollectBenchmarkSucceeded](../WDLs/CollectBenchmarkSucceeded.wdl)
 * Usage: `python <<CODE [CODE HERE] CODE`
 * Version Notes: 
-    * 1.0: Versions are `python3` 3.9.9, `pandas` 1.3.4, `numpy` 1.21.4, `scipy` 1.7.2, `firecloud` 0.16.32, 
-    `fsspec` 2022.7.1, `gcsfs` 2022.7.1.
+  * 1.0: Versions are `python3` 3.9.9, `pandas` 1.3.4, `numpy` 1.21.4, `scipy` 1.7.2, `firecloud` 0.16.32, 
+  `fsspec` 2022.7.1, `gcsfs` 2022.7.1.
 
 ## python-data-slim-plots
 
@@ -40,8 +40,8 @@ with the libraries `pandas`, `numpy`, `scipy`, `firecloud`, `fsspec` (a `fireclo
 * Description: Based on `python-data-slim`, this image supports plotting with [matplotlib](https://matplotlib.org/) and [Plotly](https://plotly.com/)
 * Location: `us.gcr.io/broad-dsde-methods/python-data-slim-plots`
 * Used By: [FunctionalEquivalence](../../FunctionalEquivalence/FunctionalEquivalence.wdl)
-* Version Notes: 
-    * 1.0: Versions are `matplotlib` 3.5.3, `plotly` 5.10.0.
+* Version Notes:
+  * 1.0: Versions are `matplotlib` 3.5.3, `plotly` 5.10.0.
     
 ## rtg
 

--- a/Utilities/Dockers/RTG/Dockerfile
+++ b/Utilities/Dockers/RTG/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR dist
 RUN unzip *.zip 
 
 # Install RTG
-WORKDIR rtg-tools-3.12.1-32d4c2d2
+WORKDIR rtg-tools-*
 RUN ln -s $(pwd)/rtg /bin/
 RUN yes no | rtg --help
 WORKDIR /root

--- a/Utilities/Dockers/RTG/Dockerfile
+++ b/Utilities/Dockers/RTG/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:22.10
+RUN apt update
+RUN apt install -y openjdk-11-jre ant git unzip python3 python3-pip
+
+# Get RTG files for install
+RUN git clone https://github.com/RealTimeGenomics/rtg-tools.git
+WORKDIR rtg-tools
+RUN ant zip-nojre
+WORKDIR dist
+RUN unzip *.zip 
+
+# Install RTG
+WORKDIR rtg-tools-3.12.1-32d4c2d2
+RUN ln -s $(pwd)/rtg /bin/
+RUN yes no | rtg --help
+WORKDIR /root
+
+# Install Python packages
+RUN pip install pandas


### PR DESCRIPTION
# Simple Benchmark

This PR introduces a rewrite of the [BenchmarkVCFs](https://github.com/broadinstitute/palantir-workflows/blob/main/BenchmarkVCFs/BenchmarkVCFs.wdl) WDL used for comparing a VCF (callset) to a baseline (base) VCF. The main goals for this project were the following:

* **Speed up the runtime in Terra.** Typical runs of BenchmarkVCFs could take anywhere from 1-6 hours, whereas the core comparison done by vcfeval takes a small fraction of that time. The original impetus for this rewrite was to peel out the most necessary tasks required to automate the comparison, without sacrificing too much functionality.
* **Fix bugs and add extra functionality.** There was a bug in the previous code where arbitrary selection via jexl selectors did not work as advertised. This should be corrected now, using `bcftools` selectors instead.
* **Expose more granular data to top level.** The comparison engine vcfeval is capable of producing lots of in depth statistics that can be useful in benchmark analysis. Previously, accessing some of this data would require either running manually yourself, or digging through different Terra directories. 
* **Add visualization tools for processing the outputs.** There is a *lot* of data output by this tool now, and organizing it all into some convenient plots can take some careful thought. Although the raw data should always be available to users for their pipelines, there is now a BenchmarkBoard visualizer tool that users can run by installing some Python packages and running a script in the same directory as the output files from the WDL. This comes in two flavors - single sample and multi-sample versions. Both are similar in the plots they produce. More details can be found in their documentation.

Details on the changes in design, usage instructions, and more can be found in the full README files included in this PR. I would recommend looking through that now if you're interested in learning more about how the proposed WDL works. After reading, if you're more curious about comparing with the old BenchmarkVCFs WDL from a developers perspective, keep reading for some more details.

----

## FAQ

In order to address some design choices that might seem a bit strange at first, I'll include this FAQ here for current and future readers to help design & debugging in the future. (Perhaps I'll be the only one who "frequently asked" myself these questions when looking back at my old code, and had to keep reminding myself why I did things this way as opposed to something seemingly simpler...)

**Q**: Why is there a weird `NONE_FILE` input into the WDL that isn't supposed to be overwritten?

**A**: This is used in a hack to create a `null` File type to continue supporting the use of having an empty interval list in the main scatter to compute stats over the "Whole Genome". This is a workaround because WDL 1.0 doesn't handle `null` data very well.

**Q**: Why use `gatk SelectVariants` for the interval subsetting tool when `bcftools` is used later? Shouldn't the latter work just fine? And can't `vcfeval` itself allow subsetting?

**A**: There are a few reasons why I chose the former over the other options:
1. `SelectVariants` allows you to use a variety of different types of interval files, including Picard interval_lists, which isn't supported by `bcftools`.
2. `SelectVariants` allows you to toggle padding on your interval lists. When the VCFs are subset, it's possible that variants right on the boundary get excised which can affect downstream statistics if your intervals are dense but short. Exposing this as an option to the WDL allows users to tweak this as appropriate.
3. Although `vcfeval` allows for subsetting via *bed* files (and not general interval_lists as well) to generate the desired ROC statistics, this option won't output any counts of FNs. This might be desirable for the user worried of large numbers of variants on the boundaries, in which case any stats involving FNs can be ignored, but the current paradigm allows you to at least get all the numbers after restricting to consider.

**Q**: Why use `bcftools` to subset variant types by expression? Doesn't `vcfeval` allow for this, and `SelectVariants` as well?

**A**: The other tools also allow for subsetting via an expressive language. In particular, `vcfeval` has the `--roc-expr` flag, which seems perfect for the task of computing granular stats over multiple subsets, and allows for multiple instances of the flag. Unfortunately, the same problem as above arises in not counting FNs. (It also won't intersect the combination of expressions and regions to subset over, rather outputting a file for each different option.) For `SelectVariants` the problem is worse -- you can't subset by variant type until everything has been labeled by `vcfeval`! Otherwise you might filter out some variants that help resolve identical haplotypes, leading to incorrect FNs/FPs. It could have been run after to do the filtering, but `bcftools stats` is very fast and computes most of the relevant stats you would want to get out of the VCFs produced by `vcfeval`. 

**Q**: Why isn't there a `CrosscheckFingerprints` step like in the old WDL? 

**A**: Although I agree it can be dangerous to run without this step, I'm not sure it belongs to this particular WDL. Currently, both BenchmarkVCFs and FindSamplesAndBenchmark run the tool. The former uses it as a safety net, whereas the latter uses it to match a bunch of samples across two lists. I think if the analogue to FSAB wrapper of this WDL gets developed, that should run the tool and be responsible for both steps at once. Of course, adding an optional task to run in this WDL wouldn't hurt if someone wants to add it. At the moment I wanted this tool to be closer to BenchmarkVCFs than to FSAB, but would imagine a wrapper that allows for a list of samples on either side should be developed and replace this as the de facto benchmarking workflow.

---

## More Things to Do

There are a few more things that might be useful to finish off at some point in the future. These include:

* Add template inputs.json files for common use cases (e.g. benchmarking GIAB, etc.). 
* Add fingerprinting check on inputs as an option.
* Add optional IGV Session generation.
* Add ROC data plot support to the multi-sample BenchmarkBoard. Other improvements to come with future releases of Quickboard. In particular, combining the single-sample and multi-sample visualizers will probably happen once more features are readily accessible in Quickboard.
