### PR TITLE
Added utilities for bam stats over intervals

### DIFF
--- a/Utilities/Dockers/README.md
+++ b/Utilities/Dockers/README.md
@@ -18,7 +18,18 @@ Also includes some minimal Python tools (pandas) for data processing.
 * Used By: [SimpleBenchmark](../../BenchmarkVCFs/SimpleBenchmark.wdl)
 * Usage: `bcftools [COMMAND]`
 * Version Notes:
-  * 1.0: Versions are `bcftools` 1.16
+  * 1.0: Versions are `bcftools` 1.16.
+
+## samtools
+
+* Directory: Samtools
+* Description: A docker image containing an installation of [samtools](https://github.com/samtools/samtools). Also
+includes some minimal Python tools (pandas) for data processing.
+* Location: `us.gcr.io/broad-dsde-methods/samtools:v1`
+* Used By: [ComputeIntervalBamStats](../IntervalFiles/ComputeIntervalBamStats.wdl)
+* Usage: `samtools [COMMAND]`
+* Version Notes:
+  * 1.0: Versions are `samtools` 1.16.1.
 
 ## python-data-slim
 

--- a/Utilities/Dockers/Samtools/Dockerfile
+++ b/Utilities/Dockers/Samtools/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:22.10
+RUN apt update
+RUN apt install -y git python3 python3-pip wget libbz2-dev liblzma-dev libcurl4-openssl-dev libncurses-dev
+
+RUN pip install pandas
+
+# Make Samtools
+RUN wget https://github.com/samtools/samtools/releases/download/1.16.1/samtools-1.16.1.tar.bz2
+RUN tar -xvf samtools-1.16.1.tar.bz2
+WORKDIR samtools-1.16.1
+RUN ./configure
+RUN make
+RUN make install
+RUN export PATH=/samtools-1.16.1/samtools:$PATH

--- a/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl
+++ b/Utilities/IntervalFiles/ComputeIntervalBamStats.wdl
@@ -1,0 +1,306 @@
+version 1.0
+
+# For computing stats/distributions over various interval files for BAM files
+workflow ComputeIntervalBamStats {
+    input {
+        String input_name
+        File input_bam
+        File input_bam_index
+        String experiment = ""
+
+        File ref_fasta
+        File ref_index
+        File ref_dict
+
+        Array[File] interval_files
+        Array[String] interval_names
+    }
+
+    scatter(interval in zip(interval_names, interval_files)) {
+        call SubsetBam {
+            input:
+                input_bam=input_bam,
+                input_bam_index=input_bam_index,
+                ref_fasta=ref_fasta,
+                ref_index=ref_index,
+                ref_dict=ref_dict,
+                interval_file=interval.right,
+                interval_name=interval.left
+        }
+
+        call ComputeWgsMetrics {
+            input:
+                input_bam=SubsetBam.bam_subset,
+                input_bam_index=SubsetBam.bam_subset_index,
+                ref_fasta=ref_fasta,
+                ref_index=ref_index,
+                ref_dict=ref_dict,
+                interval_file=interval.right,
+                interval_name=interval.left
+        }
+
+        call ComputeMAPQDistribution {
+            input:
+                input_bam=SubsetBam.bam_subset,
+                input_bam_index=SubsetBam.bam_subset_index,
+                interval_file=interval.right,
+                interval_name=interval.left
+        }
+    }
+
+    call CollectCoverageResults {
+        input:
+            input_name=input_name,
+            experiment=experiment,
+            wgs_files=ComputeWgsMetrics.wgs_file
+    }
+
+    call CollectMAPQResults {
+        input:
+            input_name=input_name,
+            experiment=experiment,
+            mapq_files=ComputeMAPQDistribution.mapq_dist
+    }
+
+    output {
+        File wgs_summary = CollectCoverageResults.wgs_summary
+        File cov_summary = CollectCoverageResults.cov_summary
+        File mapq_summary = CollectMAPQResults.mapq_summary
+    }
+}
+
+task SubsetBam {
+    input {
+        File input_bam
+        File input_bam_index
+
+        File ref_fasta
+        File ref_index
+        File ref_dict
+
+        File interval_file
+        String interval_name
+
+        String gatk_tag = "4.3.0.0"
+        Int disk_size = 2 * ceil(size(input_bam, "GB")) + 25
+        Int cpu = 8
+        Int memory = 32
+    }
+
+    parameter_meta {
+        input_bam: {
+           localization_optional: true
+       }
+    }
+
+    command <<<
+        set -xueo pipefail
+
+        gatk PrintReads \
+            -I ~{input_bam} \
+            -L ~{interval_file} \
+            -O "~{interval_name}.bam"
+
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-gatk/gatk:" + gatk_tag
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory + " GB"
+    }
+
+    output {
+        File bam_subset = "~{interval_name}.bam"
+        File bam_subset_index = "~{interval_name}.bai"
+    }
+}
+
+# For coverage-related stats and distribution
+task ComputeWgsMetrics {
+    input {
+        File input_bam
+        File input_bam_index
+
+        File ref_fasta
+        File ref_index
+        File ref_dict
+
+        File interval_file
+        String interval_name
+
+        # Tool arguments
+        Int min_BQ = 20
+        Int min_MQ = 20
+        Int coverage_cap = 250
+
+        # Runtime
+        String gatk_tag = "4.3.0.0"
+        Int disk_size = 2 * ceil(size(input_bam, "GB")) + 25
+        Int cpu = 8
+        Int memory = 32
+    }
+
+    command <<<
+        set -xueo pipefail
+
+        gatk CollectWgsMetrics \
+            -I ~{input_bam} \
+            -R ~{ref_fasta} \
+            -O "~{interval_name}.wgs_metrics" \
+            --INTERVALS ~{interval_file} \
+            ~{"--MINIMUM_BASE_QUALITY " + min_BQ} \
+            ~{"--MINIMUM_MAPPING_QUALITY " + min_MQ} \
+            ~{"--COVERAGE_CAP " + coverage_cap}
+
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-gatk/gatk:" + gatk_tag
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory + " GB"
+    }
+
+    output {
+        File wgs_file = "~{interval_name}.wgs_metrics"
+    }
+}
+
+task ComputeMAPQDistribution {
+    input {
+        File input_bam
+        File input_bam_index
+
+        File interval_file
+        String interval_name
+
+        # Runtime
+        Int cpu = 8
+        Int memory = 16
+        Int extra_disk = 25
+
+    }
+
+    Int disk_size = 2*ceil(size(input_bam, "GB")) + extra_disk
+
+    command <<<
+        set -xueo pipefail
+
+        samtools view ~{input_bam} | awk '{print $5}' | sort -n | uniq -c > "~{interval_name}_mapq_dist.txt"
+
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/samtools:v1"
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory + " GB"
+    }
+
+    output {
+        File mapq_dist = "~{interval_name}_mapq_dist.txt"
+    }
+}
+
+task CollectMAPQResults {
+    input {
+        String input_name
+        String experiment
+        Array[File] mapq_files
+
+        Int disk_size = 50
+        Int cpu = 2
+        Int memory = 8
+    }
+
+    command <<<
+        python3 << CODE
+
+        import os
+        import pandas as pd
+
+        file_paths = ["~{default="" sep="\", \"" mapq_files}"]
+        full_mapq_summary = pd.DataFrame()
+
+        for file in file_paths:
+            interval_name = os.path.basename(file).split('_mapq_dist.txt')[0]
+
+            mapq_summary = pd.read_csv(file, sep='\s+', names=['Count', 'MAPQ'])
+            mapq_summary['Interval_List'] = interval_name
+            mapq_summary['Sample'] = "~{input_name}"
+            mapq_summary['Experiment'] = "~{experiment}"
+            full_mapq_summary = pd.concat([full_mapq_summary, mapq_summary])
+
+        full_mapq_summary.to_csv("mapq_summary.tsv", sep='\t', index=False)
+
+        CODE
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory + "GB"
+    }
+
+    output {
+        File mapq_summary = "mapq_summary.tsv"
+    }
+}
+
+
+task CollectCoverageResults {
+    input {
+        String input_name
+        String experiment
+        Array[File] wgs_files
+
+        Int disk_size = 50
+        Int cpu = 2
+        Int memory = 8
+    }
+
+    command <<<
+        python3 << CODE
+
+        import os
+        import pandas as pd
+
+        file_paths = ["~{default="" sep="\", \"" wgs_files}"]
+        full_wgs_summary = pd.DataFrame()
+        full_cov_summary = pd.DataFrame()
+
+        for file in file_paths:
+            interval_name = os.path.basename(file).split('.wgs_metrics')[0]
+
+            wgs_summary = pd.read_csv(file, sep='\t', comment='#', nrows=1)
+            wgs_summary['Interval_List'] = interval_name
+            wgs_summary['Sample'] = "~{input_name}"
+            wgs_summary['Experiment'] = "~{experiment}"
+            full_wgs_summary = pd.concat([full_wgs_summary, wgs_summary])
+
+            cov_dist = pd.read_csv(file, sep='\t', skiprows=10)
+            cov_dist['Interval_List'] = interval_name
+            cov_dist['Sample'] = "~{input_name}"
+            cov_dist['Experiment'] = "~{experiment}"
+            full_cov_summary = pd.concat([full_cov_summary, cov_dist])
+
+        full_wgs_summary.to_csv("wgs_summary.tsv", sep='\t', index=False)
+        full_cov_summary.to_csv("cov_summary.tsv", sep='\t', index=False)
+
+        CODE
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory + "GB"
+    }
+
+    output {
+        File wgs_summary = "wgs_summary.tsv"
+        File cov_summary = "cov_summary.tsv"
+    }
+}

--- a/Utilities/IntervalFiles/README.md
+++ b/Utilities/IntervalFiles/README.md
@@ -37,14 +37,19 @@ were computed.
 
 ### Reference Specific
 
-These are interval files which are intrinsic to fixed reference genome sequences (hg38 for this version).
+These are interval files which are intrinsic to fixed reference genome sequences (hg38 for this version). Each has three
+mirror locations: one bed, one interval_list with hg38 header, and one interval_list with hg38 minus alt contigs for 
+its sequence dictionary (no-alt). Full lists of each category are collected in the [Using on Terra](#using-on-terra) section.
 
 #### HighGC
 * Summary: Contains regions in reference consisting of 100bp windows with more than 85% GC bases. Note the `slop50` in
 the file name references adding 50 bases of padding on either side of the window using 
 [bedtools](https://bedtools.readthedocs.io/en/latest/content/tools/slop.html), so the list is the union of 200-length
 intervals with interior 100bps having high GC content. Note other thresholds than 85% are available from NIST.
-* Bucket Mirror: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_gc85_slop50.bed.gz`
+* Bucket Mirrors: 
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_gc85_slop50.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_gc85_slop50.interval_list`
+  * interval_list (no-alt):  `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_gc85_slop50.interval_list`
 * Original File: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/GCcontent/GRCh38_gc85_slop50.bed.gz)
 * Original Documentation: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/GCcontent/GRCh38-GCcontent-README.md)
 * Percent of Genome: 0.01%
@@ -53,7 +58,10 @@ intervals with interior 100bps having high GC content. Note other thresholds tha
 
 #### LowGC
 * Summary: Same as HighGC, but with inner windows containing less than 15% GC bases.
-* Bucket Mirror: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_gc15_slop50.bed.gz`
+* Bucket Mirrors: 
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_lt15_slop50.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_lt15_slop50.interval_list`
+  * interval_list (no-alt): `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_lt15_slop50.interval_list`
 * Original File: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/GCcontent/GRCh38_gc15_slop50.bed.gz)
 * Original Documentation: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/GCcontent/GRCh38-GCcontent-README.md)
 * Percent of Genome: 0.2%
@@ -66,7 +74,10 @@ intervals with interior 100bps having high GC content. Note other thresholds tha
 (low stringency), and regions of length >= 250 with exact alignment matches (high stringency). Note that while 
 conceptually one might expect the latter to be a subset of regions in the former, the latter list has a few more sites
 than seen in the former (0.03% of high stringency not seen in low). Refinements to either subset is available from NIST. 
-* Bucket Mirror: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_lowmappabilityall.bed.gz`
+* Bucket Mirrors: 
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_lowmappabilityall.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_lowmappabilityall.interval_list`
+  * interval_list (no-alt): `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_lowmappabilityall.interval_list`
 * Original File: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/mappability/GRCh38_lowmappabilityall.bed.gz)
 * Original Documentation: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/mappability/GRCh38-mappability-README.md)
 * Percent of Genome: 8%
@@ -79,7 +90,10 @@ than seen in the former (0.03% of high stringency not seen in low). Refinements 
 #### Homopolymers
 * Summary: Contains regions in reference which are homopolymers (repeated base) of length >= 6 and imperfect homopolymers
   (homopolymers interrupted by 1 different base) of length >= 10, with 5 bases added on both sides for padding.
-* Bucket Mirror: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_AllHomopolymers_gt6bp_imperfectgt10bp_slop5.bed.gz`
+* Bucket Mirrors: 
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_AllHomopolymers_gt6bp_imperfectgt10bp_slop5.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_AllHomopolymers_gt6bp_imperfectgt10bp_slop5.interval_list`
+  * interval_list (no-alt): `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_AllHomopolymers_gt6bp_imperfectgt10bp_slop5.interval_list`
 * Original File: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/LowComplexity/GRCh38_AllHomopolymers_gt6bp_imperfectgt10bp_slop5.bed.gz)
 * Original Documentation: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/LowComplexity/GRCh38-LowComplexity-README.md)
 * Percent of Genome: 2.7%
@@ -91,7 +105,10 @@ than seen in the former (0.03% of high stringency not seen in low). Refinements 
 
 #### LowComplexityRegion
 * Summary: Contains regions of "low complexity", using the symmetric DUST algorithm. 
-* Bucket Mirror: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/LCRFromHengHg38.bed`
+* Bucket Mirrors: 
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/LCRFromHengHg38.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/LCRFromHengHg38.interval_list`
+  * interval_list (no-alt): `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_LCRFromHeng.interval_list`
 * Original File: [here](https://github.com/broadinstitute/hydro.gen/blob/main/Data/LCRFromHengHg38.bed) 
 * Original Documentation: [here](https://github.com/broadinstitute/hydro.gen/tree/main/Data)
 * Percent of Genome: 2%
@@ -102,7 +119,10 @@ than seen in the former (0.03% of high stringency not seen in low). Refinements 
 
 #### SegDup
 * Summary: Contains regions of segmental duplications, i.e. regions where the reference aligns to itself. 
-* Bucket Mirror:  `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_segdups.bed.gz`
+* Bucket Mirrors:  
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_segdups.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_segdups.interval_list`
+  * interval_list (no-alt): `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_segdups.interval_list`
 * Original File: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/SegmentalDuplications/GRCh38_segdups.bed.gz)
 * Original Documentation: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/SegmentalDuplications/GRCh38-SegDups-README.md)
 * Percent of Genome: 5.4%
@@ -114,7 +134,10 @@ than seen in the former (0.03% of high stringency not seen in low). Refinements 
 #### AllDifficult
 * Summary: Contains regions pooled from various "difficult" regions, including all tandem repeats, homopolymers of length >= 6,
 segmental duplications, and more. Note this includes a few "function specific" interval lists like BadPromoters.
-* Bucket Mirror: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_alldifficultregions.bed.gz`
+* Bucket Mirrors: 
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_alldifficultregions.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_alldifficultregions.interval_list`
+  * interval_list (no-alt): `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_alldifficultregions.interval_list`
 * Original File: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/Union/GRCh38_alldifficultregions.bed.gz)
 * Original Documentation: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/Union/GRCh38-Union-README.md)
 * Percent of Genome: 21%
@@ -132,7 +155,10 @@ These are interval files which are related to inferred biological functioning of
 
 #### Exome
 * Summary: Contains exome with additional padding (50bp) and a few other modifications. 
-* Bucket Mirror: `gs://gcp-public-data--broad-references/hg38/v0/exome_evaluation_regions.v1.interval_list`
+* Bucket Mirrors: 
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/exome_evaluation_regions.v1.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/exome_evaluation_regions.v1.interval_list`
+  * interval_list (no-alt): `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/exome_evaluation_regions.v1-noalt.interval_list`
 * Original File: Same as bucket.
 * Original Documentation: Script to generate found [here](https://github.com/broadinstitute/warp/blob/ldgauthier-patch-splitintervals/scripts/generate_hg38_exome_calling_intervals.v1.1.sh)
 * Percent of Genome: 1.14%
@@ -144,7 +170,10 @@ These are interval files which are related to inferred biological functioning of
 #### CodingRegions
 * Summary: Contains regions strictly formed from coding regions, as identified by RefSeq. In essence, this is conceptually 
 a stricter exome interval file, though there is not a strict containment.
-* Bucket Mirror: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_refseq_cds.bed.gz`
+* Bucket Mirrors: 
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_refseq_cds.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_refseq_cds.interval_list`
+  * interval_list (no-alt): `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_refseq_cds.interval_list`
 * Original File: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/FunctionalRegions/GRCh38_refseq_cds.bed.gz)
 * Original Documentation: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/FunctionalRegions/GRCh38-FunctionalRegions-README.md)
 * Percent of Genome: 1.10%
@@ -153,7 +182,10 @@ a stricter exome interval file, though there is not a strict containment.
 
 #### BadPromoters
 * Summary: Contains regions where transcription site or first exons have systematically low coverage.
-* Bucket Mirror: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_BadPromoters.bed.gz`
+* Bucket Mirrors: 
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_BadPromoters.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_BadPromoters.interval_list`
+  * interval_list (no-alt): `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_BadPromoters.interval_list` 
 * Original File: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/FunctionalTechnicallyDifficultRegions/GRCh38_BadPromoters.bed.gz)
 * Original Documentation: [here](https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/genome-stratifications/v3.1/GRCh38/FunctionalTechnicallyDifficultRegions/GRCh38-FunctionalTechnicallyDifficult-README.md)
 * Percent of Genome: 0.006%
@@ -177,7 +209,10 @@ These are interval lists that are relevant only for analyzing data from specific
 "difficult" regions for Ultima sequencers. The full list can be found in the original documentation, but this includes
 homopolymers of length >= 11 (+4 bases for padding), GC < 5%, and 50bp windows with highly variable coverage between
 samples.
-* Bucket Mirror: `gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/interval_lists/ug_hcr.bed`
+* Bucket Mirrors: 
+  * bed: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/ug_hcr.bed`
+  * interval_list: `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/ug_hcr.interval_list`
+  * interval_list (no-alt): `gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/ug_hcr-noalt.interval_list`
 * Original File: Same as bucket.
 * Original Documentation: [here](https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/ultima_genomics/interval_lists/README.txt)
 * Percent of Genome: 89.5%
@@ -187,21 +222,52 @@ samples.
 ## Using on Terra
 
 Here is a formatted list of the above interval files along with a list of names in the same order, so you can easily
-use any subset of them when running a benchmarking tool on Terra.
+use any subset of them when running a benchmarking tool on Terra. Depending on your workflow, you might require bed
+or interval list files, so we provide collected lists of both.
 
 ```
-strat_intervals = [
-"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_gc85_slop50.bed.gz",
-"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_gc15_slop50.bed.gz",
-"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_lowmappabilityall.bed.gz",
-"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_AllHomopolymers_gt6bp_imperfectgt10bp_slop5.bed.gz",
+strat_intervals_bed = [
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_gc85_slop50.bed",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_lt15_slop50.bed",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_lowmappabilityall.bed",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_AllHomopolymers_gt6bp_imperfectgt10bp_slop5.bed",
 "gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/LCRFromHengHg38.bed",
-"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_segdups.bed.gz",
-"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_alldifficultregions.bed.gz",
-"gs://gcp-public-data--broad-references/hg38/v0/exome_evaluation_regions.v1.interval_list",
-"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_refseq_cds.bed.gz",
-"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_BadPromoters.bed.gz",
-"gs://gcp-public-data--broad-references/hg38/v0/ultima_genomics/interval_lists/ug_hcr.bed",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_segdups.bed",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_alldifficultregions.bed",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/exome_evaluation_regions.v1.bed",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_refseq_cds.bed",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_BadPromoters.bed",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/ug_hcr.bed"
+]
+
+# Interval Lists w/ full hg38 sequence dictionary
+strat_interval_lists = [
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_gc85_slop50.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_lt15_slop50.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_lowmappabilityall.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_AllHomopolymers_gt6bp_imperfectgt10bp_slop5.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/LCRFromHengHg38.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_segdups.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_alldifficultregions.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/exome_evaluation_regions.v1.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_refseq_cds.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38_BadPromoters.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/ug_hcr.interval_list"
+]
+
+# Interval Lists w/ hg38 sequence dictionary without alt contigs
+strat_interval_lists_no_alt = [
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_gc85_slop50.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_lt15_slop50.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_lowmappabilityall.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_AllHomopolymers_gt6bp_imperfectgt10bp_slop5.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_LCRFromHeng.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_segdups.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_alldifficultregions.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/exome_evaluation_regions.v1-noalt.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_refseq_cds.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/GRCh38-noalt_BadPromoters.interval_list",
+"gs://broad-dsde-methods-hydro-gen-truth-data-public/IntervalFiles/ug_hcr-noalt.interval_list"
 ]
 
 strat_labels = [


### PR DESCRIPTION
This PR includes a few additions and changes for computations over interval lists. The main components are:
* Added `ComputeIntervalBamStats.wdl`, which is a workflow that takes in a bam file, a list of interval lists, and some other metadata which computes Picard's CollectWgsMetrics on the bam over those intervals, along with a mapping quality distribution for each region. These statistics are then collected and labeled over the groups into a few output tsvs that are ready to be visualized (dashboard coming soon, maybe!). The `input_name` and `experiment` inputs are added as columns to the output, to allow concatenation of outputs across multiple sample runs and easy grouping into `experiment` groups when plotting. 
* Added a simple docker with `samtools`, which is used in the above workflow.
* Fixed some naming conventions/locations for interval files previously added. In particular, each interval file has an incarnation as a bed file, a classic interval_list with hg38 seq dict header, and an interval_list with a restricted hg38 seq dict to exclude alt-contigs. This last one was mostly relevant to some experiments I was doing without alt contigs, but might be more generally useful for workflows which try to avoid those contigs and don't want fussy tools to complain about mismatched sequence dicts. 