### PR TITLE
AggregatePRSResults updates

### DIFF
--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -343,14 +343,14 @@ task BuildHTMLReport {
     #### Hover for sample ID
     \`\`\`{r pca plot, echo=FALSE, message=FALSE, warning=FALSE, results="asis", fig.align='center'}
     target_pcs <- read_tsv("~{batch_pcs}")
+    target_pcs <- target_pcs %>% mutate(text = paste0("Sample ID: ", sample_id), color=factor(ifelse(sample_id %in% samples_high_risk, "~{lab_batch} High Risk", "~{lab_batch} Not High Risk"), levels=c("~{lab_batch} Not High Risk", "~{lab_batch} High Risk")))
     population_pcs <- read_tsv("~{population_pc_projections}")
 
     p <- ggplot(population_pcs, aes(x=PC1, y=PC2, color="~{population_name}")) +
       geom_point() +
-      geom_point(data=target_pcs %>% filter(!(sample_id %in% samples_high_risk)), aes(color="~{lab_batch} Not High Risk", text=paste0("Sample ID: ", sample_id))) +
-      geom_point(data=target_pcs %>% filter(sample_id %in% samples_high_risk), aes(color="~{lab_batch} High Risk", text=paste0("Sample ID: ", sample_id))) +
-    scale_color_manual(values=c("~{population_name}"="grey", "~{lab_batch} Not High Risk"="#619CFF", "~{lab_batch} High Risk"="#F8766D")) +
-    theme_bw()
+      geom_point(data=target_pcs, aes( color = color, text=text)) +
+      scale_color_manual(values=c("~{population_name}"="grey", "~{lab_batch} Not High Risk"="#619CFF", "~{lab_batch} High Risk"="#F8766D")) +
+      theme_bw()
     ggplotly(p, tooltip="text")
     \`\`\`
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -307,7 +307,7 @@ task BuildHTMLReport {
 
     # Conditions Scored per Sample
     \`\`\`{r conditions scored per sample, echo = FALSE, results = "asis", warning = FALSE}
-    observed_condition_groups <- observed_condition_groups %>% mutate(across(everything(), ~kableExtra::cel_spec(.x, color=ifelse(group=="not allowed", "red", "white"))))
+    observed_condition_groups <- observed_condition_groups %>% mutate(across(everything(), ~kableExtra::cell_spec(.x, color=ifelse(group=="not allowed", "red", "white"))))
     kable(observed_condition_groups, escape = FALSE, fromat = "pandoc")
     \`\`\`
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -349,7 +349,7 @@ task BuildHTMLReport {
       geom_point() +
       geom_point(data=target_pcs %>% filter(!(sample_id %in% samples_high_risk)), aes(color="~{lab_batch} Not High Risk", text=paste0("Sample ID: ", sample_id))) +
       geom_point(data=target_pcs %>% filter(sample_id %in% samples_high_risk), aes(color="~{lab_batch} High Risk", text=paste0("Sample ID: ", sample_id))) +
-    scale_color_manual(values=c("~{population_name}"="grey", "~{lab_batch} Not High Risk"="#619CFF", "~{lab_batch}High Risk"="#F8766D")) +
+    scale_color_manual(values=c("~{population_name}"="grey", "~{lab_batch} Not High Risk"="#619CFF", "~{lab_batch} High Risk"="#F8766D")) +
     theme_bw()
     ggplotly(p, tooltip="text")
     \`\`\`

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -306,7 +306,7 @@ task BuildHTMLReport {
     \`\`\`
 
     # Conditions Scored per Sample
-    \`\`\`
+    \`\`\`{r conditions scored per sample, echo = FALSE, results = "asis", warning = FALSE}
     observed_condition_groups <- observed_condition_groups %>% mutate(across(everything(), ~kableExtra::cel_spec(.x, color=ifelse(group=="not allowed", "red", "white"))))
     kable(observed_condition_groups, escape = FALSE, fromat = "pandoc")
     \`\`\`

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -277,6 +277,8 @@ task BuildHTMLReport {
       summarise(\`high risk conditions\` = paste(condition, collapse = ","), n=n()) %>%
       filter(n>1) %>% inner_join(threshold_set_per_sample) %>% group_by(sample_id, \`high risk conditions\`, n, thresholds) %>% filter(n_high >= n) %>%
       summarise(significance=paste0(signif(qnorm(1-sum(prob)),2), "\\U03C3")) %>% select(-n,-thresholds)
+
+    samples_high_risk <- batch_pivoted_results %>% filter(risk == "HIGH") %>% pull(sample_id) %>% unique()
     \`\`\`
 
     \`\`\`{css, echo=FALSE}
@@ -345,8 +347,10 @@ task BuildHTMLReport {
 
     p <- ggplot(population_pcs, aes(x=PC1, y=PC2, color="~{population_name}")) +
       geom_point() +
-      geom_point(data=target_pcs, aes(color="~{lab_batch}", text=paste0("Sample ID: ", sample_id))) +
-      theme_bw()
+      geom_point(data=target_pcs %>% filter(!(sample_id %in% samples_high_risk)), aes(color="~{lab_batch} Not High Risk", text=paste0("Sample ID: ", sample_id))) +
+      geom_point(data=target_pcs %>% filter(sample_id %in% samples_high_risk), aes(color="~{lab_batch} High Risk", text=paste0("Sample ID: ", sample_id))) +
+    scale_color_manual(values=c("~{population_name}"="grey", "~{lab_batch} Not High Risk"="#619CFF", "~{lab_batch}High Risk"="#F8766D")) +
+    theme_bw()
     ggplotly(p, tooltip="text")
     \`\`\`
 

--- a/ImputationPipeline/AggregatePRSResults.wdl
+++ b/ImputationPipeline/AggregatePRSResults.wdl
@@ -307,8 +307,8 @@ task BuildHTMLReport {
 
     # Conditions Scored per Sample
     \`\`\`{r conditions scored per sample, echo = FALSE, results = "asis", warning = FALSE}
-    observed_condition_groups <- observed_condition_groups %>% mutate(across(everything(), ~kableExtra::cell_spec(.x, color=ifelse(group=="not allowed", "red", "white"))))
-    kable(observed_condition_groups, escape = FALSE, fromat = "pandoc")
+    observed_condition_groups <- observed_condition_groups %>% mutate(across(everything(), ~kableExtra::cell_spec(.x, color=ifelse(group=="not allowed", "red", "black"))))
+    kable(observed_condition_groups, escape = FALSE, format = "pandoc")
     \`\`\`
 
     ## Samples High Risk for Multiple Conditions

--- a/test/AggregatePRSResults/plumbing_data/condition_groups.tsv
+++ b/test/AggregatePRSResults/plumbing_data/condition_groups.tsv
@@ -1,0 +1,9 @@
+group	condition
+group_1	condition_1
+group_1	condition_2
+group_1	condition_3
+group_2	condition_1
+group_2	condition_2
+group_2	condition_3
+group_2	condition_4
+group_3	condition_4

--- a/test/AggregatePRSResults/test_AggregatePRSResults.wdl
+++ b/test/AggregatePRSResults/test_AggregatePRSResults.wdl
@@ -19,6 +19,7 @@ workflow test_AggregatePRSResults {
         File expected_batch_summarised_results
         File expected_batch_pcs
         File allowed_condition_groups
+        Float control_sample_diff_threshold
     }
     
     call AggregatePRSResults.AggregatePRSResults {
@@ -32,7 +33,8 @@ workflow test_AggregatePRSResults {
             expected_control_results = expected_control_results,
             lab_batch = lab_batch,
             group_n = group_n,
-            allowed_condition_groups = allowed_condition_groups
+            allowed_condition_groups = allowed_condition_groups,
+            control_sample_diff_threshold = control_sample_diff_threshold
     }
     
     call CompareTextFiles {

--- a/test/AggregatePRSResults/test_AggregatePRSResults.wdl
+++ b/test/AggregatePRSResults/test_AggregatePRSResults.wdl
@@ -18,6 +18,7 @@ workflow test_AggregatePRSResults {
         File expected_batch_control_results
         File expected_batch_summarised_results
         File expected_batch_pcs
+        File allowed_condition_groups
     }
     
     call AggregatePRSResults.AggregatePRSResults {
@@ -30,7 +31,8 @@ workflow test_AggregatePRSResults {
             population_name = population_name,
             expected_control_results = expected_control_results,
             lab_batch = lab_batch,
-            group_n = group_n
+            group_n = group_n,
+            allowed_condition_groups = allowed_condition_groups
     }
     
     call CompareTextFiles {

--- a/test/AggregatePRSResults/test_AggregatePRSResults_json/test_plumbing_inputs.json
+++ b/test/AggregatePRSResults/test_AggregatePRSResults_json/test_plumbing_inputs.json
@@ -17,5 +17,6 @@
   "test_AggregatePRSResults.expected_batch_all_results":"/home/circleci/project/test/AggregatePRSResults/plumbing_data/expected_batch_all_results.tsv",
   "test_AggregatePRSResults.expected_batch_control_results":"/home/circleci/project/test/AggregatePRSResults/plumbing_data/expected_batch_control_results.tsv",
   "test_AggregatePRSResults.expected_batch_summarised_results": "/home/circleci/project/test/AggregatePRSResults/plumbing_data/expected_batch_summarised_results.tsv",
-  "test_AggregatePRSResults.expected_batch_pcs":"/home/circleci/project/test/AggregatePRSResults/plumbing_data/expected_batch_pcs.tsv"
+  "test_AggregatePRSResults.expected_batch_pcs":"/home/circleci/project/test/AggregatePRSResults/plumbing_data/expected_batch_pcs.tsv",
+  "test_AggregatePRSResults.allowed_condition_groups":"/home/circleci/project/test/AggregatePRSResults/plumbing_data/condition_groups.tsv"
 }

--- a/test/AggregatePRSResults/test_AggregatePRSResults_json/test_plumbing_inputs.json
+++ b/test/AggregatePRSResults/test_AggregatePRSResults_json/test_plumbing_inputs.json
@@ -18,5 +18,6 @@
   "test_AggregatePRSResults.expected_batch_control_results":"/home/circleci/project/test/AggregatePRSResults/plumbing_data/expected_batch_control_results.tsv",
   "test_AggregatePRSResults.expected_batch_summarised_results": "/home/circleci/project/test/AggregatePRSResults/plumbing_data/expected_batch_summarised_results.tsv",
   "test_AggregatePRSResults.expected_batch_pcs":"/home/circleci/project/test/AggregatePRSResults/plumbing_data/expected_batch_pcs.tsv",
-  "test_AggregatePRSResults.allowed_condition_groups":"/home/circleci/project/test/AggregatePRSResults/plumbing_data/condition_groups.tsv"
+  "test_AggregatePRSResults.allowed_condition_groups":"/home/circleci/project/test/AggregatePRSResults/plumbing_data/condition_groups.tsv",
+  "test_AggregatePRSResults.control_sample_diff_threshold" : 0.12
 }


### PR DESCRIPTION
Three improvements:

1. Adds a check that samples are only scored for allowed combinations of conditions.  Displays the number of samples scored for each allowed condition grouping, as well as listing the samples for any unallowed condition groupings.
2. In PCA plot, differentiates (by color) samples with at least 1 high risk condition from those with none.
3. Makes the threshold at which a condition is visually flagged for an unexpected control sample value a parameter of the workflow (instead of being hardcoded as 0.12)