### PR TITLE
Added a pipeline for phasing VCFs and benchmarking their performance with WhatsHap

### DIFF
--- a/BenchmarkPhasing/BenchmarkPhasing.wdl
+++ b/BenchmarkPhasing/BenchmarkPhasing.wdl
@@ -1,0 +1,162 @@
+version 1.0
+
+workflow BenchmarkPhasing {
+    input {
+        File base_vcf
+        File base_vcf_index
+        String? base_sample_name
+
+        File call_vcf
+        File call_vcf_index
+        String? call_sample_name
+
+        String? experiment
+
+        Array[File]? interval_beds
+        Array[String]? interval_bed_labels
+    }
+
+    call WhatsHapCompare {
+        input:
+            base_vcf=base_vcf,
+            base_vcf_index=base_vcf_index,
+            base_sample_name=base_sample_name,
+            call_vcf=call_vcf,
+            call_vcf_index=call_vcf_index,
+            call_sample_name=call_sample_name,
+            experiment=experiment
+    }
+
+    if (defined(interval_beds)) {
+        call EvaluateRegions {
+            input:
+                switch_errors_bed=WhatsHapCompare.switch_errors_bed,
+                call_sample_name=call_sample_name,
+                experiment=experiment,
+                interval_beds=select_first([interval_beds]),
+                interval_bed_labels=select_first([interval_bed_labels])
+        }
+    }
+
+    output {
+        File whatshap_eval = WhatsHapCompare.eval
+        File switch_errors_bed = WhatsHapCompare.switch_errors_bed
+        File longest_blocks = WhatsHapCompare.longest_blocks
+        File jaccard_table = select_first([EvaluateRegions.jaccard_table, ""])
+    }
+}
+
+task WhatsHapCompare {
+    input {
+        File base_vcf
+        File base_vcf_index
+        String? base_sample_name
+
+        File call_vcf
+        File call_vcf_index
+        String? call_sample_name
+
+        String? experiment
+
+        Boolean only_snvs = false    # Toggle to only consider phasing for SNVs
+
+        # Runtime arguments
+        Int disk_size = 2 * ceil(size(base_vcf, "GB") + size(call_vcf, "GB")) + 50
+        Int cpu = 4
+        Int memory_ram = 16
+    }
+
+    command <<<
+        set -xue
+
+        whatshap compare \
+        --names ~{default="truth" base_sample_name},~{default="callset" call_sample_name} \
+        --tsv-pairwise eval.tsv \
+        --ignore-sample-name \
+        ~{true="--only-snvs" false="" only_snvs} \
+        --switch-error-bed switch_errors.bed \
+        --longest-block-tsv longest_blocks.tsv \
+        ~{base_vcf} ~{call_vcf}
+
+        echo "Experiment" > exp_column.txt
+        yes ~{experiment} | head -n $(cat eval.tsv | wc -l) | sed -e '1d' >> exp_column.txt
+        paste exp_column.txt eval.tsv > final-eval.tsv
+
+        echo "Experiment" > exp_column.txt
+        yes ~{experiment} | head -n $(cat longest_blocks.tsv | wc -l) | sed -e '1d' >> exp_column.txt
+        paste exp_column.txt longest_blocks.tsv > final-longest_blocks.tsv
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/whatshap:v1"
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory_ram + " GB"
+    }
+
+    output {
+        File eval = "final-eval.tsv"
+        File switch_errors_bed = "switch_errors.bed"
+        File longest_blocks = "final-longest_blocks.tsv"
+    }
+}
+
+task EvaluateRegions {
+    input {
+        File switch_errors_bed
+
+        String? call_sample_name
+        String? experiment
+
+        Array[File] interval_beds
+        Array[String] interval_bed_labels
+
+        # Runtime arguments
+        Int disk_size = 2 * ceil(size(switch_errors_bed, "GB") + size(interval_beds, "GB")) + 50
+        Int cpu = 4
+        Int memory_ram = 16
+    }
+
+    command <<<
+        set -xue
+
+        INTERVAL_BEDS=(~{sep=' ' interval_beds})
+        INTERVAL_LABELS=(~{sep=' ' interval_bed_labels})
+
+        > full-jaccard.tsv
+
+        for i in {0..~{length(interval_beds)-1}}
+        do
+        bedtools intersect -a "${INTERVAL_BEDS[$i]}" -b ~{switch_errors_bed} > intersect.bed
+        bedtools sort -i intersect.bed > intersect-sorted.bed
+        bedtools jaccard -a intersect-sorted.bed -b ~{switch_errors_bed} > jaccard.tsv
+        tail -n 1 jaccard.tsv > contents.tsv
+        echo "${INTERVAL_LABELS[$i]}" > names.txt
+        paste names.txt contents.tsv >> full-jaccard.tsv
+        done
+
+        # Add header back
+        echo -e "Interval_Name\tintersection\tunion\tjaccard\tn_intersections" > header.txt
+        cat header.txt full-jaccard.tsv > header-jaccard.tsv
+
+        # Add constant columns
+        echo "Experiment" > exp_column.txt
+        yes ~{experiment} | head -n $(cat header-jaccard.tsv | wc -l) | sed -e '1d' >> exp_column.txt
+        paste exp_column.txt header-jaccard.tsv > jaccard-no_sample.tsv
+
+        echo "Sample" > sample_column.txt
+        yes ~{call_sample_name} | head -n $(cat jaccard-no_sample.tsv | wc -l) | sed -e '1d' >> sample_column.txt
+        paste sample_column.txt jaccard-no_sample.tsv > final-jaccard.tsv
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/bedtools:v1.0"
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory_ram + " GB"
+    }
+
+    output {
+        File jaccard_table = "final-jaccard.tsv"
+    }
+}

--- a/BenchmarkPhasing/BenchmarkPhasing.wdl
+++ b/BenchmarkPhasing/BenchmarkPhasing.wdl
@@ -70,13 +70,13 @@ task WhatsHapCompare {
         set -xue
 
         whatshap compare \
-        --names ~{default="truth" base_sample_name},~{default="callset" call_sample_name} \
-        --tsv-pairwise eval.tsv \
-        --ignore-sample-name \
-        ~{true="--only-snvs" false="" only_snvs} \
-        --switch-error-bed switch_errors.bed \
-        --longest-block-tsv longest_blocks.tsv \
-        ~{base_vcf} ~{call_vcf}
+            --names ~{default="truth" base_sample_name},~{default="callset" call_sample_name} \
+            --tsv-pairwise eval.tsv \
+            --ignore-sample-name \
+            ~{true="--only-snvs" false="" only_snvs} \
+            --switch-error-bed switch_errors.bed \
+            --longest-block-tsv longest_blocks.tsv \
+            ~{base_vcf} ~{call_vcf}
 
         echo "Experiment" > exp_column.txt
         yes ~{experiment} | head -n $(cat eval.tsv | wc -l) | sed -e '1d' >> exp_column.txt
@@ -123,16 +123,19 @@ task EvaluateRegions {
         INTERVAL_BEDS=(~{sep=' ' interval_beds})
         INTERVAL_LABELS=(~{sep=' ' interval_bed_labels})
 
-        > full-jaccard.tsv
-
+        # For each interval bed, we want to compute the proportion of switch errors occuring in that region.
+        # This is achieved by first intersecting the two bed files, and then using bedtools to compute the
+        # Jaccard index of the two (compute the size of the intersection over the full switch error file).
+        # Finally add a column with the interval label in it for downstream data analysis.
         for i in {0..~{length(interval_beds)-1}}
         do
-        bedtools intersect -a "${INTERVAL_BEDS[$i]}" -b ~{switch_errors_bed} > intersect.bed
-        bedtools sort -i intersect.bed > intersect-sorted.bed
-        bedtools jaccard -a intersect-sorted.bed -b ~{switch_errors_bed} > jaccard.tsv
-        tail -n 1 jaccard.tsv > contents.tsv
-        echo "${INTERVAL_LABELS[$i]}" > names.txt
-        paste names.txt contents.tsv >> full-jaccard.tsv
+            bedtools intersect -a "${INTERVAL_BEDS[$i]}" -b ~{switch_errors_bed} > intersect.bed
+            bedtools sort -i intersect.bed > intersect-sorted.bed
+            bedtools jaccard -a intersect-sorted.bed -b ~{switch_errors_bed} > jaccard.tsv
+            tail -n 1 jaccard.tsv > contents.tsv
+
+            echo "${INTERVAL_LABELS[$i]}" > names.txt
+            paste names.txt contents.tsv >> full-jaccard.tsv
         done
 
         # Add header back

--- a/BenchmarkPhasing/PhaseVCF.wdl
+++ b/BenchmarkPhasing/PhaseVCF.wdl
@@ -1,0 +1,90 @@
+version 1.0
+
+workflow PhaseVCF {
+    input {
+        File input_vcf
+        File input_vcf_index
+        String? input_sample_name
+
+        File input_bam
+        File input_bam_index
+
+        File reference_fasta
+        File reference_fasta_index
+    }
+
+    call WhatsHapPhase {
+        input:
+            input_vcf=input_vcf,
+            input_vcf_index=input_vcf_index,
+            input_sample_name=input_sample_name,
+            input_bam=input_bam,
+            input_bam_index=input_bam_index,
+            reference_fasta=reference_fasta,
+            reference_fasta_index=reference_fasta_index
+    }
+
+    output {
+        File phased_vcf = WhatsHapPhase.phased_vcf
+        File phased_vcf_index = WhatsHapPhase.phased_vcf_index
+        File phase_stats = WhatsHapPhase.phase_stats
+    }
+}
+
+task WhatsHapPhase {
+    input {
+        File input_vcf
+        File input_vcf_index
+        String? input_sample_name    # Required if ignore_read_groups false && multi-sample VCF
+
+        File input_bam
+        File input_bam_index
+
+        File reference_fasta
+        File reference_fasta_index
+
+        # Tool arguments
+        Boolean ignore_read_groups = true    # Switch to false to phase by Read Groups (RG)
+        Boolean distrust_genotypes = false    # Turn on to allow hets -> hom if it allows optimal phasing solution
+        File? pedigree
+        String tag = "PS"    # Other option: HP
+        Float? recombrate     # Recombination rate to use (1.26 for humans); change for non-human samples
+
+        # Runtime arguments
+        Int disk_size = ceil(2 * size(input_vcf, "GB") + size(input_bam, "GB") + size(reference_fasta, "GB")) + 50
+        Int cpu = 8
+        Int memory_ram = 64
+    }
+
+    command <<<
+        set -xueo pipefail
+
+        whatshap phase \
+        --reference=~{reference_fasta} \
+        -o phased.vcf.gz \
+        --tag=~{tag} \
+        ~{"--ped" + pedigree} \
+        ~{true="--ignore-read-groups" false="" ignore_read_groups} \
+        ~{true="--distrust-genotypes" false="" distrust_genotypes} \
+        ~{"--recombrate" + recombrate} \
+        ~{input_vcf} \
+        ~{input_bam}
+
+        tabix phased.vcf.gz
+        whatshap stats --tsv="phase_stats.tsv" phased.vcf.gz
+
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/whatshap:v1"
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory_ram + " GB"
+    }
+
+    output {
+        File phased_vcf = "phased.vcf.gz"
+        File phased_vcf_index = "phased.vcf.gz.tbi"
+        File phase_stats = "phase_stats.tsv"
+    }
+}

--- a/BenchmarkPhasing/PhaseVCF.wdl
+++ b/BenchmarkPhasing/PhaseVCF.wdl
@@ -60,15 +60,15 @@ task WhatsHapPhase {
         set -xueo pipefail
 
         whatshap phase \
-        --reference=~{reference_fasta} \
-        -o phased.vcf.gz \
-        --tag=~{tag} \
-        ~{"--ped" + pedigree} \
-        ~{true="--ignore-read-groups" false="" ignore_read_groups} \
-        ~{true="--distrust-genotypes" false="" distrust_genotypes} \
-        ~{"--recombrate" + recombrate} \
-        ~{input_vcf} \
-        ~{input_bam}
+            --reference=~{reference_fasta} \
+            -o phased.vcf.gz \
+            --tag=~{tag} \
+            ~{"--ped" + pedigree} \
+            ~{true="--ignore-read-groups" false="" ignore_read_groups} \
+            ~{true="--distrust-genotypes" false="" distrust_genotypes} \
+            ~{"--recombrate" + recombrate} \
+            ~{input_vcf} \
+            ~{input_bam}
 
         tabix phased.vcf.gz
         whatshap stats --tsv="phase_stats.tsv" phased.vcf.gz

--- a/BenchmarkPhasing/README.md
+++ b/BenchmarkPhasing/README.md
@@ -1,0 +1,82 @@
+# Benchmark Phasing
+
+This directory contains some workflows related to phasing. The concept of phasing includes understanding how nearby 
+heterozygous variants are oriented relative to each other, i.e. on the same contig or opposite in diploid samples.
+Here we have a workflow for computing this information, and for benchmarking samples that have already been phased.
+When used together, this creates a pipeline for testing how phasing information has changed from one set of experimental
+conditions to another.
+
+1. [The Phasing WDL](#the-phasing-wdl)
+2. [The Benchmarking WDL](#the-benchmarking-wdl)
+
+
+## The Phasing WDL
+
+This WDL adds phasing information to a VCF using read information.
+
+The WDL [PhaseVCF](PhaseVCF.wdl) has the following input/output schema.
+
+### Inputs
+
+- `input_vcf`: the VCF to add phasing information to
+- `input_vcf_index`: the index for the input VCF
+- `input_sample_name`: optional but recommended input 
+- `input_bam`: the read alignments (BAM) to use for linking nearby variants
+- `input_bam_index`: the index for the input BAM
+- `reference_fasta`: reference file 
+- `reference_fasta_index`: index for the reference file
+
+### Outputs
+
+- `phased_vcf`: the input VCF with phasing information added, when possible
+- `phased_vcf_index`: the index for the phased VCF
+- `phase_stats`: a tsv of stats produced via `whatshap stats`
+
+### Tool Options
+
+Some options can be toggled in the `WhatsHapPhase` task for different behaviors. See the 
+[tool documentation](https://whatshap.readthedocs.io/en/latest/guide.html) for a full description. Included options are:
+
+- `ignore_read_groups`: (default = `true`) If false, phase samples using RGs
+- `distrust_genotypes`: (default = `false`) If true, allow hets to be treated as homs if it allows for an optimal phasing solution
+- `pedigree`: (optional) When included, use `.ped` file to strengthen phasing capabilities by leveraging trios consensus
+- `tag`: (default = `PS`) tag for labeling phasing information; other option is `HP`
+- `recombrate`: (optional) Toggle for non-human samples to better reflect species recombination rate
+
+
+## The Benchmarking WDL
+
+This WDL compares two phased VCFs and collects statistics about errors in the "callset" VCF against a "baseline" VCF. 
+In contrast with benchmarking short variants for their genotypes, different error rate statistics are collected based
+on inconsistencies in the call VCF's phasing against the baseline. More details can be found in the 
+[WhatsHap documentation](https://whatshap.readthedocs.io/en/latest/guide.html#whatshap-compare).
+
+The WDL [BenchmarkPhasing](BenchmarkPhasing.wdl) has the following input/output schema.
+
+### Inputs
+
+- `base_vcf`: the VCF to use as a baseline or "truth" data for phasing
+- `base_vcf_index`: the index for the baseline VCF
+- `base_sample_name`: (optional) the nickname to use for the sample in the `base_vcf`, as referenced in output tables
+- `call_vcf`: the VCF "callset" to compare phasing against the baseline
+- `call_vcf_index`: the index for the call VCF
+- `call_sample_name`: (optional) the nickname to use for the sample in the `call_vcf`, as referenced in output tables
+- `experiment`: (optional) label to use for the "Experiment" column in outputs; useful for downstream data analysis
+- `interval_beds`: (optional) array of `.bed` files to use for creating the `jaccard_table` output
+- `interval_bed_labels`: (optional) array of labels for the `.bed` files to use in the output tables
+
+### Outputs
+
+- `whatshap_eval`: the evaluation output containing error statistics
+- `switch_errors_bed`: a bed file containing locations of switch errors
+- `longest_blocks`: a tsv containing the variants in the longest phased block in each contig
+- `jaccard_table`: if `.bed` files were provided, a table of the Jaccard index of the `switch_errors_bed` and  its intersection
+with the input `.bed` files; this statistic reflects what percentage of the switch errors occured in each of the `.bed` files.
+
+### Tool Options
+
+Some options can be toggled in the `WhatsHapCompare` task for different behaviors. See the 
+[tool documentation](https://whatshap.readthedocs.io/en/latest/guide.html#whatshap-compare) for more details. Included
+options are:
+
+- `only_snvs`: (default = `false`) If true, only use SNVs in phasing comparison

--- a/Utilities/Dockers/Bedtools/Dockerfile
+++ b/Utilities/Dockers/Bedtools/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.10
+
+RUN apt update
+RUN apt install -y wget
+RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.30.0/bedtools.static.binary
+RUN mv bedtools.static.binary bedtools
+RUN chmod a+x bedtools
+RUN mv bedtools /root/bedtools
+ENV PATH="${PATH}:/root/"
+

--- a/Utilities/Dockers/Bedtools/Dockerfile
+++ b/Utilities/Dockers/Bedtools/Dockerfile
@@ -1,10 +1,6 @@
 FROM ubuntu:22.10
 
-RUN apt update
-RUN apt install -y wget
-RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.30.0/bedtools.static.binary
-RUN mv bedtools.static.binary bedtools
-RUN chmod a+x bedtools
-RUN mv bedtools /root/bedtools
+ADD https://github.com/arq5x/bedtools2/releases/download/v2.30.0/bedtools.static.binary /root/bedtools
+RUN chmod 755 /root/bedtools
 ENV PATH="${PATH}:/root/"
 

--- a/Utilities/Dockers/README.md
+++ b/Utilities/Dockers/README.md
@@ -20,6 +20,16 @@ Also includes some minimal Python tools (pandas) for data processing.
 * Version Notes:
   * 1.0: Versions are `bcftools` 1.16.
 
+## bedtools
+
+* Directory: Bedtools
+* Description: A docker image containing an installation of [bedtools](https://bedtools.readthedocs.io/en/latest/).
+* Location: `us.gcr.io/broad-dsde-methods/bedtools:v1.0`
+* Used By: [BenchmarkPhasing](../../BenchmarkPhasing/BenchmarkPhasing.wdl)
+* Usage: `bedtools [COMMAND]`
+* Version Notes:
+  * 1.0: Versions are `bedtools` 2.30.0
+
 ## samtools
 
 * Directory: Samtools
@@ -75,3 +85,13 @@ convenient data manipulation tools.
 * Usage: `rtg [COMMAND]`
 * Version Notes: 
   * 1.0: Versions are `rtg` 3.12.1
+
+## whatshap
+
+* Directory: WhatsHap
+* Description: A docker image containing an installation of [WhatsHap](https://whatshap.readthedocs.io/en/latest/).
+* Location: `us.gcr.io/broad-dsde-methods/whatshap:v1`
+* Used By: [BenchmarkPhasing](../../BenchmarkPhasing/BenchmarkPhasing.wdl), [PhaseVCF](../../BenchmarkPhasing/PhaseVCF.wdl)
+* Usage: `whatshap [COMMAND]`
+* Version Notes:
+  * 1.0: Versions are `whatshap` 1.7

--- a/Utilities/Dockers/WhatsHap/Dockerfile
+++ b/Utilities/Dockers/WhatsHap/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:23.04
+RUN apt update
+RUN apt install -y git python3 python3-pip python3-dev build-essential libbz2-dev liblzma-dev libcurl4-openssl-dev libncurses-dev tabix
+
+RUN pip install whatshap==1.7
+
+RUN export PATH=$HOME/.local/bin:$PATH

--- a/Utilities/Dockers/WhatsHap/Dockerfile
+++ b/Utilities/Dockers/WhatsHap/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:23.04
-RUN apt update
-RUN apt install -y git python3 python3-pip python3-dev build-essential libbz2-dev liblzma-dev libcurl4-openssl-dev libncurses-dev tabix
-
-RUN pip install whatshap==1.7
+RUN apt-get update && \
+    apt-get install -y git python3 python3-pip python3-dev build-essential libbz2-dev liblzma-dev libcurl4-openssl-dev libncurses-dev tabix && \
+    pip install whatshap==1.7 && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN export PATH=$HOME/.local/bin:$PATH


### PR DESCRIPTION
As the title suggests, this PR contains the following:
- A workflow for phasing a VCF using an input bam with WhatsHap
- A workflow for benchmarking a phased VCF against a baseline using WhatsHap
- Some dockers to facilitate these new workflows

More detailed documentation can be found in the /BenchmarkPhasing/README.md. 

Note I haven't done much comparison across tools yet, so future development could include allowing the choice between WhatsHap and other phasing engines, similar to our old benchmarking script. For now I wanted to collect these together just to have something. 