### PR TITLE
Update for PRS on hg38

### DIFF
--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -102,14 +102,20 @@ workflow ScoringImputedDataset {
 		File sites_to_use_in_scoring = select_first([ExtractIDsPopulation.ids, sites_used_in_scoring_for_model])
 	}
 
+	call ScoringTasks.DetermineChromosomeEncoding {
+		input:
+			weights = named_weight_set.weight_set.linear_weights
+	}
+
 	call ScoringTasks.ScoreVcf as ScoreImputedArray {
 		input:
-		vcf = imputed_array_vcf,
-		basename = basename,
-		weights = named_weight_set.weight_set.linear_weights,
-		base_mem = scoring_mem,
-		extra_args = columns_for_scoring,
-		sites = sites_to_use_in_scoring
+			vcf = imputed_array_vcf,
+			basename = basename,
+			weights = named_weight_set.weight_set.linear_weights,
+			base_mem = scoring_mem,
+			extra_args = columns_for_scoring,
+			sites = sites_to_use_in_scoring,
+			chromosome_encoding = DetermineChromosomeEnoding.chromosome_encoding
 	}
 
 	if (defined(named_weight_set.weight_set.interaction_weights)) {

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -98,6 +98,10 @@ workflow ScoringImputedDataset {
 		}
 	}
 
+	if (defined(ExtractIDsPopulation.ids) || defined(sites_used_in_scoring_for_model)) {
+		File sites_to_use_in_scoring = select_first([ExtractIDsPopulation.ids, sites_used_in_scoring_for_model])
+	}
+
 	call ScoringTasks.ScoreVcf as ScoreImputedArray {
 		input:
 		vcf = imputed_array_vcf,
@@ -105,7 +109,7 @@ workflow ScoringImputedDataset {
 		weights = named_weight_set.weight_set.linear_weights,
 		base_mem = scoring_mem,
 		extra_args = columns_for_scoring,
-		sites = select_first([ExtractIDsPopulation.ids, sites_used_in_scoring_for_model])
+		sites = sites_to_use_in_scoring
 	}
 
 	if (defined(named_weight_set.weight_set.interaction_weights)) {
@@ -114,7 +118,7 @@ workflow ScoringImputedDataset {
 				vcf = imputed_array_vcf,
 				interaction_weights = select_first([named_weight_set.weight_set.interaction_weights]),
 				scores = ScoreImputedArray.score,
-				sites = select_first([ExtractIDsPopulation.ids, sites_used_in_scoring_for_model]),
+				sites = sites_to_use_in_scoring,
 				basename = basename,
 				self_exclusive_sites = named_weight_set.weight_set.interaction_self_exclusive_sites
 		}

--- a/ImputationPipeline/ScoringPart.wdl
+++ b/ImputationPipeline/ScoringPart.wdl
@@ -115,7 +115,7 @@ workflow ScoringImputedDataset {
 			base_mem = scoring_mem,
 			extra_args = columns_for_scoring,
 			sites = sites_to_use_in_scoring,
-			chromosome_encoding = DetermineChromosomeEnoding.chromosome_encoding
+			chromosome_encoding = DetermineChromosomeEncoding.chromosome_encoding
 	}
 
 	if (defined(named_weight_set.weight_set.interaction_weights)) {

--- a/ImputationPipeline/ScoringTasks.wdl
+++ b/ImputationPipeline/ScoringTasks.wdl
@@ -659,7 +659,7 @@ task DetermineChromosomeEncoding {
     python3 << "EOF"
     code = 'MT'
     with open("~{weights}") as weights_file:
-      chroms = {s.split("\t")[0].split(":")[0] for s in weights_file if ":" in s}
+      chroms = {s.split("\t")[0].split(":")[0] for i, s in weights_file if i > 0}
       if any('chr' in c for c in chroms):
           if 'chrM' in chroms:
               code = 'chrM'

--- a/ImputationPipeline/ScoringTasks.wdl
+++ b/ImputationPipeline/ScoringTasks.wdl
@@ -18,7 +18,7 @@ task ScoreVcf {
   Int runtime_mem = base_mem + 2
   Int plink_mem = ceil(base_mem * 0.75 * 1000)
   Int disk_space =  3*ceil(size(vcf, "GB")) + 20
-  String var_ids_string = "@:#:" + if use_ref_alt_for_ids then "\$r:\$a" else "\$1:\$2"
+  String var_ids_string = "@:#:" + if use_ref_alt_for_ids then "\\$r:\\$a" else "\\$1:\\$2"
 
   command {
     /plink2 --score ~{weights} header ignore-dup-ids list-variants no-mean-imputation \

--- a/ImputationPipeline/ScoringTasks.wdl
+++ b/ImputationPipeline/ScoringTasks.wdl
@@ -659,7 +659,7 @@ task DetermineChromosomeEncoding {
     python3 << "EOF"
     code = 'MT'
     with open("~{weights}") as weights_file:
-      chroms = {s.split("\t")[0].split(":")[0] for i, s in weights_file if i > 0}
+      chroms = {s.split("\t")[0].split(":")[0] for i, s in enumerate(weights_file) if i > 0}
       if any('chr' in c for c in chroms):
           if 'chrM' in chroms:
               code = 'chrM'

--- a/ImputationPipeline/ScoringTasks.wdl
+++ b/ImputationPipeline/ScoringTasks.wdl
@@ -657,19 +657,19 @@ task DetermineChromosomeEncoding {
 
   command <<<
     python3 << "EOF"
-      with open(~{weights}) as weights_file:
-      chroms = {s.split("\t")[0].split(":")[0] for s in weights_file if ":" in s}
-      code = 'MT'
-      if any('chr' in c for c in chroms):
-          if 'chrM' in chroms:
-              code = 'chrM'
-          else:
-              code = 'chrMT'
-      elif 'M' in chroms:
-          code = 'M'
+    with open(~{weights}) as weights_file:
+    chroms = {s.split("\t")[0].split(":")[0] for s in weights_file if ":" in s}
+    code = 'MT'
+    if any('chr' in c for c in chroms):
+        if 'chrM' in chroms:
+            code = 'chrM'
+        else:
+            code = 'chrMT'
+    elif 'M' in chroms:
+        code = 'M'
 
-      with open('chr_encode_out.txt', 'w') as write_code_file:
-          write_code_file.write(f'{code}\n')
+    with open('chr_encode_out.txt', 'w') as write_code_file:
+        write_code_file.write(f'{code}\n')
     EOF
   >>>
 

--- a/ImputationPipeline/ScoringTasks.wdl
+++ b/ImputationPipeline/ScoringTasks.wdl
@@ -657,7 +657,7 @@ task DetermineChromosomeEncoding {
 
   command <<<
     python3 << "EOF"
-    with open(~{weights}) as weights_file:
+    with open("~{weights}") as weights_file:
     chroms = {s.split("\t")[0].split(":")[0] for s in weights_file if ":" in s}
     code = 'MT'
     if any('chr' in c for c in chroms):

--- a/ImputationPipeline/ScoringTasks.wdl
+++ b/ImputationPipeline/ScoringTasks.wdl
@@ -12,15 +12,17 @@ task ScoreVcf {
     String? extra_args
     File? sites
     String? chromosome_encoding
+    Boolean use_ref_alt_for_ids = false
   }
 
   Int runtime_mem = base_mem + 2
   Int plink_mem = ceil(base_mem * 0.75 * 1000)
   Int disk_space =  3*ceil(size(vcf, "GB")) + 20
+  String var_ids_string = "@:#:" + if use_ref_alt_for_ids then "\$r:\$a" else "\$1:\$2"
 
   command {
     /plink2 --score ~{weights} header ignore-dup-ids list-variants no-mean-imputation \
-    cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --set-all-var-ids @:#:\$1:\$2 --allow-extra-chr ~{extra_args} -vcf ~{vcf} dosage=DS \
+    cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --set-all-var-ids ~{var_ids_string} --allow-extra-chr ~{extra_args} -vcf ~{vcf} dosage=DS \
     --new-id-max-allele-len 1000 missing ~{"--extract " + sites} --out ~{basename} --memory ~{plink_mem} ~{"--output-chr " + chromosome_encoding}
   }
 

--- a/ImputationPipeline/ScoringTasks.wdl
+++ b/ImputationPipeline/ScoringTasks.wdl
@@ -11,6 +11,7 @@ task ScoreVcf {
     Int base_mem = 8
     String? extra_args
     File? sites
+    String? chromosome_encoding
   }
 
   Int runtime_mem = base_mem + 2
@@ -20,7 +21,7 @@ task ScoreVcf {
   command {
     /plink2 --score ~{weights} header ignore-dup-ids list-variants no-mean-imputation \
     cols=maybefid,maybesid,phenos,dosagesum,scoreavgs,scoresums --set-all-var-ids @:#:\$1:\$2 --allow-extra-chr ~{extra_args} -vcf ~{vcf} dosage=DS \
-    --new-id-max-allele-len 1000 missing ~{"--extract " + sites} --out ~{basename} --memory ~{plink_mem}
+    --new-id-max-allele-len 1000 missing ~{"--extract " + sites} --out ~{basename} --memory ~{plink_mem} ~{"--output-chr " + chromosome_encoding}
   }
 
   output {

--- a/ImputationPipeline/ScoringTasks.wdl
+++ b/ImputationPipeline/ScoringTasks.wdl
@@ -657,16 +657,16 @@ task DetermineChromosomeEncoding {
 
   command <<<
     python3 << "EOF"
-    with open("~{weights}") as weights_file:
-    chroms = {s.split("\t")[0].split(":")[0] for s in weights_file if ":" in s}
     code = 'MT'
-    if any('chr' in c for c in chroms):
-        if 'chrM' in chroms:
-            code = 'chrM'
-        else:
-            code = 'chrMT'
-    elif 'M' in chroms:
-        code = 'M'
+    with open("~{weights}") as weights_file:
+      chroms = {s.split("\t")[0].split(":")[0] for s in weights_file if ":" in s}
+      if any('chr' in c for c in chroms):
+          if 'chrM' in chroms:
+              code = 'chrM'
+          else:
+              code = 'chrMT'
+      elif 'M' in chroms:
+          code = 'M'
 
     with open('chr_encode_out.txt', 'w') as write_code_file:
         write_code_file.write(f'{code}\n')


### PR DESCRIPTION
A few improvements, and enabling scoring on hg38

1. plink needs to be explicitly told to allow `chr` on the beginning of chromosome names.  The pipeline now looks at the weights file to automatically determine the chromosome naming pattern that should be passed to plink.
2. an option is now available to code sites as `chr:pos:ref:alt` instead of `chr:pos:a1:a2` (where a1, a2 are in lexicographical order).  This allows indels to be included which could otherwise be ambiguous (if a vcf includes an A--> AA insertion and an AA --> A deletion at the same site, for example).  The default is still to use `chr:pos:a1:a2`, not because this is the encouraged method (it isn't and should be avoided if possible), but to avoid changing default behavior, at least for the time being.
3. there was a bug which meant that a list of sites to subset to before scoring was effectively required, even though it wasn't supposed to be.  this is fixed now.