### PR TITLE
Add utility for creating IGV session from list of bams, vcfs, intervals

### DIFF
--- a/Utilities/WDLs/CreateIGVSession.wdl
+++ b/Utilities/WDLs/CreateIGVSession.wdl
@@ -6,7 +6,7 @@ workflow CreateIGVSession {
         Array[String]? vcfs
         Array[String]? interval_files
 
-        String ref_fasta
+        String reference
 
         String output_name = "igv_session"
     }
@@ -16,7 +16,7 @@ workflow CreateIGVSession {
             bams=bams,
             vcfs=vcfs,
             interval_files=interval_files,
-            ref_fasta=ref_fasta,
+            reference=reference,
             output_name=output_name
     }
 

--- a/Utilities/WDLs/CreateIGVSession.wdl
+++ b/Utilities/WDLs/CreateIGVSession.wdl
@@ -1,0 +1,141 @@
+version 1.0
+
+workflow CreateIGVSession {
+    input {
+        Array[String]? bams
+        Array[String]? vcfs
+        Array[String]? interval_files
+
+        String ref_fasta
+
+        String output_name = "igv_session"
+    }
+
+    call MakeIGVXML {
+        input:
+            bams=bams,
+            vcfs=vcfs,
+            interval_files=interval_files,
+            ref_fasta=ref_fasta,
+            output_name=output_name
+    }
+
+
+    output {
+        File igv_session = MakeIGVXML.igv_session
+    }
+}
+
+task MakeIGVXML {
+    input {
+        Array[String]? bams
+        Array[String]? vcfs
+        Array[String]? interval_files
+
+        String ref_fasta
+
+        String output_name = "igv_session"
+    }
+
+    Int disk_size = 50
+    Int cpu = 2
+    Int memory = 8
+
+    command <<<
+        set -xueo pipefail
+
+        python << CODE
+        import xml.etree.ElementTree as ET
+
+        # Parse WDL array into Python lists
+        bams_list = ["~{default="" sep="\" , \"" bams}"]
+        vcfs_list = ["~{default="" sep="\" , \"" vcfs}"]
+        interval_files_list = ["~{default="" sep="\" , \"" interval_files}"]
+
+        # Build XML file using nodes in ElementTree, with 'Session' at root
+        session = ET.Element('Session')
+
+        # Check reference sequence based on Terra defaults; else use provided reference
+        if "~{ref_fasta}" == "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta":
+            session.set('genome', 'hg38')
+        elif "~{ref_fasta}" == "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta":
+            session.set('genome', 'hg19')
+        else:
+            session.set('genome', "~{ref_fasta}")    # Requires IGV v2.1+
+
+        # Create resources object to hold all files
+        resources = ET.SubElement(session, 'Resources')
+
+        # Add all resources from BAMs
+
+        for bam in bams_list:
+            bam_name = bam.split('/')[-1]
+
+            bam_panel = ET.SubElement(session, 'Panel')
+            bam_panel.set('name', f'{bam_name}-BAMPanel')
+
+            res = ET.SubElement(resources, 'Resource')
+            res.set('path', bam)
+            res.set('type', 'bam')
+
+            cov_track = ET.SubElement(bam_panel, 'Track')
+            cov_track.set('id', f'{bam}_coverage')
+            cov_track.set('name', f'{bam_name} Coverage')
+
+            track = ET.SubElement(bam_panel, 'Track')
+            track.set('id', bam)
+            track.set('name', bam_name)
+
+        # Add all resources from VCFs and VCF track
+        vcf_panel = ET.SubElement(session, 'Panel')
+        vcf_panel.set('name', 'VCFPanel')
+        for vcf in vcfs_list:
+            res = ET.SubElement(resources, 'Resource')
+            res.set('path', vcf)
+            res.set('type', 'vcf')
+
+            vcf_name = vcf.split('/')[-1]
+            track = ET.SubElement(vcf_panel, 'Track')
+            track.set('id', vcf)
+            track.set('name', vcf_name)
+
+        # Create tracks for intervals and reference
+        feature_panel = ET.SubElement(session, 'Panel')
+        feature_panel.set('name', 'FeaturePanel')
+
+        # Add each interval_file to resources and lower track
+        for interval_file in interval_files_list:
+            res = ET.SubElement(resources, 'Resource')
+            res.set('path', interval_file)
+            interval_type = interval_file.split('.')[-1]    # Check if .bed or .interval_list
+            res.set('type', interval_type)
+
+            interval_name = interval_file.split('/')[-1]
+            track = ET.SubElement(feature_panel, 'Track')
+            track.set('id', interval_file)
+            track.set('name', interval_name)
+
+        # Make reference sequence visible
+        ref_seq = ET.SubElement(feature_panel, 'Track')
+        ref_seq.set('id', 'Reference sequence')
+        ref_seq.set('name', 'Reference sequence')
+
+        # Collect session into ElementTree and write to XML file with header
+        xml = ET.ElementTree(session)
+        xml.write('~{output_name}.xml', encoding='UTF-8', xml_declaration=True)
+
+        CODE
+
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/python-data-slim:1.0"
+        disks: "local-disk " + disk_size + " HDD"
+        cpu: cpu
+        memory: memory + "GB"
+    }
+
+    output {
+        File igv_session = "~{output_name}.xml"
+    }
+}

--- a/Utilities/WDLs/CreateIGVSession.wdl
+++ b/Utilities/WDLs/CreateIGVSession.wdl
@@ -32,7 +32,7 @@ task MakeIGVXML {
         Array[String]? vcfs
         Array[String]? interval_files
 
-        String ref_fasta
+        String reference
 
         String output_name = "igv_session"
     }
@@ -56,12 +56,12 @@ task MakeIGVXML {
         session = ET.Element('Session')
 
         # Check reference sequence based on Terra defaults; else use provided reference
-        if "~{ref_fasta}" == "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta":
+        if "~{reference}" == "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta" or "~{reference}" == "hg38":
             session.set('genome', 'hg38')
-        elif "~{ref_fasta}" == "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta":
+        elif "~{reference}" == "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta" or "~{reference}" == "hg19":
             session.set('genome', 'hg19')
         else:
-            session.set('genome', "~{ref_fasta}")    # Requires IGV v2.1+
+            session.set('genome', "~{reference}")    # Requires IGV v2.1+
 
         # Create resources object to hold all files
         resources = ET.SubElement(session, 'Resources')

--- a/Utilities/WDLs/CreateIGVSession.wdl
+++ b/Utilities/WDLs/CreateIGVSession.wdl
@@ -67,53 +67,58 @@ task MakeIGVXML {
         resources = ET.SubElement(session, 'Resources')
 
         # Add all resources from BAMs
+        # Each bam has its own panel
+        if len(bams_list) > 0 and bams_list[0] != '':
+            for bam in bams_list:
+                bam_name = bam.split('/')[-1]
 
-        for bam in bams_list:
-            bam_name = bam.split('/')[-1]
+                bam_panel = ET.SubElement(session, 'Panel')
+                bam_panel.set('name', f'{bam_name}-BAMPanel')
 
-            bam_panel = ET.SubElement(session, 'Panel')
-            bam_panel.set('name', f'{bam_name}-BAMPanel')
+                res = ET.SubElement(resources, 'Resource')
+                res.set('path', bam)
+                res.set('type', 'bam')
 
-            res = ET.SubElement(resources, 'Resource')
-            res.set('path', bam)
-            res.set('type', 'bam')
+                cov_track = ET.SubElement(bam_panel, 'Track')
+                cov_track.set('id', f'{bam}_coverage')
+                cov_track.set('name', f'{bam_name} Coverage')
 
-            cov_track = ET.SubElement(bam_panel, 'Track')
-            cov_track.set('id', f'{bam}_coverage')
-            cov_track.set('name', f'{bam_name} Coverage')
-
-            track = ET.SubElement(bam_panel, 'Track')
-            track.set('id', bam)
-            track.set('name', bam_name)
+                track = ET.SubElement(bam_panel, 'Track')
+                track.set('id', bam)
+                track.set('name', bam_name)
 
         # Add all resources from VCFs and VCF track
-        vcf_panel = ET.SubElement(session, 'Panel')
-        vcf_panel.set('name', 'VCFPanel')
-        for vcf in vcfs_list:
-            res = ET.SubElement(resources, 'Resource')
-            res.set('path', vcf)
-            res.set('type', 'vcf')
+        # All VCFs in one panel
+        if len(vcfs_list) > 0 and vcfs_list[0] != '':
+            vcf_panel = ET.SubElement(session, 'Panel')
+            vcf_panel.set('name', 'VCFPanel')
 
-            vcf_name = vcf.split('/')[-1]
-            track = ET.SubElement(vcf_panel, 'Track')
-            track.set('id', vcf)
-            track.set('name', vcf_name)
+            for vcf in vcfs_list:
+                res = ET.SubElement(resources, 'Resource')
+                res.set('path', vcf)
+                res.set('type', 'vcf')
+
+                vcf_name = vcf.split('/')[-1]
+                track = ET.SubElement(vcf_panel, 'Track')
+                track.set('id', vcf)
+                track.set('name', vcf_name)
 
         # Create tracks for intervals and reference
         feature_panel = ET.SubElement(session, 'Panel')
         feature_panel.set('name', 'FeaturePanel')
 
         # Add each interval_file to resources and lower track
-        for interval_file in interval_files_list:
-            res = ET.SubElement(resources, 'Resource')
-            res.set('path', interval_file)
-            interval_type = interval_file.split('.')[-1]    # Check if .bed or .interval_list
-            res.set('type', interval_type)
+        if len(interval_files_list) > 0 and interval_files_list[0] != '':
+            for interval_file in interval_files_list:
+                res = ET.SubElement(resources, 'Resource')
+                res.set('path', interval_file)
+                interval_type = interval_file.split('.')[-1]    # Check if .bed or .interval_list
+                res.set('type', interval_type)
 
-            interval_name = interval_file.split('/')[-1]
-            track = ET.SubElement(feature_panel, 'Track')
-            track.set('id', interval_file)
-            track.set('name', interval_name)
+                interval_name = interval_file.split('/')[-1]
+                track = ET.SubElement(feature_panel, 'Track')
+                track.set('id', interval_file)
+                track.set('name', interval_name)
 
         # Make reference sequence visible
         ref_seq = ET.SubElement(feature_panel, 'Track')

--- a/Utilities/WDLs/README.md
+++ b/Utilities/WDLs/README.md
@@ -3,6 +3,7 @@
 This directory contains a collection of miscellaneous WDLs useful for some small tasks. Check below for documentation on each.
 
 * [CollectBenchmarkSucceeded](#collectbenchmarksucceeded)
+* [CreateIGVSession](#createigvsession)
 * [Dipcall](#dipcall)
 * [IndexCramOrBam](#indexcramorbam)
 * [DownsampleAndCollectCoverage](#downsampleandcollectcoverage)
@@ -22,6 +23,24 @@ the successful outputs and aggregate them into one .csv, similar to the last tas
   in Terra, then this should be `<my_project>` as a string.
 * `workspace_name`: specific name for your workspace, e.g. `<my_workspace>` in the last example.
 * `submission_id`: the submission id for the `FindSamplesAndBenchmark` run, found from the "Job History" tab.
+
+## CreateIGVSession
+
+### Summary
+
+This workflow takes in optional lists of BAMs, VCFs, and interval files (`.interval_list` or `.bed`) and combines them together
+into an IGV session .xml file. A reference must be provided, either by a hardcoded string ("hg38" or "hg19"), or by providing a 
+path to the desired fasta. Input files are interpreted as WDL strings, so no localization occurs. Bucket paths are output in the .xml
+session, so IGV will stream them directly from the cloud. This task is useful to add to the end of workflows that output lots of files
+you might want to visualize together for analysis or debugging.
+
+### Inputs
+
+* `bams`: (optional) list of BAMs/CRAMs to add to session.
+* `vcfs`: (optional) list of VCFs to add to session.
+* `interval_files`: (optional) list of `.interval_list` or `.bed` files to add to session.
+* `reference`: reference to use in IGV; must be either a `.fasta` file or one of the values: "hg38" or "hg19".
+* `output_name`: (default = "igv_session") name for the output .xml file.
 
 ## Dipcall
 


### PR DESCRIPTION
A very short PR to add a utility for automating the process of creating an IGV session XML given (optional) list of bams, vcfs, or interval files (.interval_list or .bed). Also takes in a `ref_fasta` to customize the reference track. 

This is meant to replace a task used in `BenchmarkVCFs.wdl` and will be imported in a future version of our benchmarking scripts, but wanted to separate this task out so other folks can easily drop it into their workflows. 