### PR TITLE
Add utility for converting interval_list to bed efficiently

### DIFF
--- a/Utilities/WDLs/Interval2Bed.wdl
+++ b/Utilities/WDLs/Interval2Bed.wdl
@@ -59,21 +59,19 @@ workflow Interval2Bed {
 task Convert {
     input {
         File interval_list
-        String? interval_label
+        String interval_label
 
-        String gatk_tag = "4.2.3.0"
+        String gatk_tag = "4.4.0.0"
         Int? preemptible
         Int disk_size = ceil(4 * size(interval_list, "GB")) + 5
         Int cpu = 4
         Int memory = 16
     }
 
-    String name = basename(interval_list, ".interval_list")
-
     command <<<
         set -xe
 
-        gatk IntervalListToBed -I ~{interval_list} -O ~{name}.bed
+        gatk IntervalListToBed -I ~{interval_list} -O ~{interval_label}.bed
     >>>
 
     runtime {
@@ -86,7 +84,7 @@ task Convert {
     }
 
     output {
-        File bed_file = "~{name}.bed"
-        String? bed_label = select_first([interval_label, name])
+        File bed_file = "~{interval_label}.bed"
+        String bed_label = interval_label
     }
 }

--- a/Utilities/WDLs/Interval2Bed.wdl
+++ b/Utilities/WDLs/Interval2Bed.wdl
@@ -1,0 +1,92 @@
+version 1.0
+
+workflow Interval2Bed {
+    input {
+        Array[File] interval_files
+        Array[String]? interval_labels
+    }
+
+    if (defined(interval_labels)) {
+        Array[Pair[String, File]] paired_intervals = zip(select_first([interval_labels]), interval_files)
+
+        scatter (p in paired_intervals) {
+            # Check that file extension is .interval_list, i.e. removing it shortens the basename
+            if (basename(p.right, ".interval_list") != basename(p.right)) {
+                call Convert as ConvertPairs {
+                    input:
+                        interval_list=p.right,
+                        interval_label=p.left
+                }
+            }
+
+            if (basename(p.right, ".bed") != basename(p.right)) {
+                File bed_file_pair = p.right
+                File bed_label_pair = p.left
+            }
+        }
+
+        Array[File] new_interval_files_pair = flatten([select_all(bed_file_pair), select_all(ConvertPairs.bed_file)])
+        Array[File] new_interval_labels_pair = flatten([select_all(bed_label_pair), select_all(ConvertPairs.bed_label)])
+    }
+
+    if (!defined(interval_labels)) {
+        scatter (f in interval_files) {
+            if (basename(f, ".interval_list") != basename(f)) {
+                call Convert as ConvertUnlabeled {
+                    input:
+                        interval_list=f,
+                        interval_label=basename(f, ".interval_list")
+                }
+            }
+
+            if (basename(f, ".bed") != basename(f)) {
+                File bed_file = f
+                String bed_label = basename(f, ".bed")
+            }
+        }
+
+        Array[File] new_interval_files = flatten([select_all(bed_file), select_all(ConvertUnlabeled.bed_file)])
+        Array[File] new_interval_labels = flatten([select_all(bed_label), select_all(ConvertUnlabeled.bed_label)])
+    }
+
+
+    output {
+        Array[File] bed_files = select_first([new_interval_files_pair, new_interval_files])
+        Array[String] bed_labels = select_first([new_interval_labels_pair, new_interval_labels])
+    }
+}
+
+task Convert {
+    input {
+        File interval_list
+        String? interval_label
+
+        String gatk_tag = "4.2.3.0"
+        Int? preemptible
+        Int disk_size = ceil(4 * size(interval_list, "GB")) + 5
+        Int cpu = 4
+        Int memory = 16
+    }
+
+    String name = basename(interval_list, ".interval_list")
+
+    command <<<
+        set -xe
+
+        gatk IntervalListToBed -I ~{interval_list} -O ~{name}.bed
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-gatk/gatk:" + gatk_tag
+        preemptible: select_first([preemptible, 0])
+        disks: "local-disk " + disk_size + " HDD"
+        bootDiskSizeGb: "16"
+        cpu: cpu
+        memory: memory + " GB"
+    }
+
+    output {
+        File bed_file = "~{name}.bed"
+        String? bed_label = select_first([interval_label, name])
+    }
+}

--- a/Utilities/WDLs/IntervalList2Bed.wdl
+++ b/Utilities/WDLs/IntervalList2Bed.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-workflow Interval2Bed {
+workflow IntervalList2Bed {
     input {
         Array[File] interval_files
         Array[String]? interval_labels

--- a/Utilities/WDLs/README.md
+++ b/Utilities/WDLs/README.md
@@ -68,6 +68,22 @@ when appropriate. Some data cleaning and indexing of the output VCF is also perf
 
 Use this WDL to index a CRAM or BAM file, using `samtools`. The type is inferred using the file extension (either `.cram` or `.bam`). 
 
+## Interval2Bed
+
+### Summary
+
+This WDL takes in a list of interval files (either `.bed` or `.interval_list`) and converts the `.interval_list` files into `.bed`. The WDL checks if any of the provided files has a `.interval_list` extension, and then will call a conversion task on it if so. This means if all the files provided are `.bed`, then no tasks will be called, and the original list will be returned. This allows you to drop this task in to your workflows to extend pipeline functionality from accepting `.bed` inputs to also handle `.interval_list` files without penalizing users who provided `.bed` files with unnecessary extra tasks, which is ideal as many tools require specifically `.bed` lists.
+
+If labels are provided, they will be returned in the new order of the `bed_files` output, which may be different than the originally given order. If labels are not provided, a list of `basename`s for the input files will be returned, in the correct order.
+
+### Inputs
+* `interval_files`: a list of `.bed` and/or `.interval_list` files
+* `interval_labels`: an optional list of string labels to use for the corresponding interval file
+
+### Outputs
+* `bed_files`: a list of `.bed` files converted to the given inputs; note the order may have changed from the given list
+* `bed_labels`: a list of labels for the `.bed` files corresponding to the user inputs, or the basename of the input files if the user did not provide any labels. Note the order may have changed, but the position of a label corresponds to the position of the file in `bed_files`.
+
 
 ## DownsampleAndCollectCoverage
 

--- a/Utilities/WDLs/README.md
+++ b/Utilities/WDLs/README.md
@@ -68,7 +68,8 @@ when appropriate. Some data cleaning and indexing of the output VCF is also perf
 
 Use this WDL to index a CRAM or BAM file, using `samtools`. The type is inferred using the file extension (either `.cram` or `.bam`). 
 
-## Interval2Bed
+
+## IntervalList2Bed
 
 ### Summary
 


### PR DESCRIPTION
This short PR adds a utility that can convert a mix of `.interval_list` and `.bed` files into a list of just `.bed` files, which is ideal for pipelines using tools that only take in `.bed` files. The WDL is designed so that if all the inputs are `.bed` files, then no tasks are called (just some simple WDL code is run), and the original list and labels are returned. This means pipelines accepting just `.bed` files can use this task as a penalty-free (for `.bed` file users) way to extend their functionality to `.interval_list`s as well. The task also allows for optional label inputs so that labels can stay "next to" their converted file and used downstream. 

See the README in this PR for more details. This utility will be used in the upcoming benchmarking WDL and others.