### PR TITLE
Add MatchFingerprints utility WDL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
   womtool-executor:
     docker:
       # specify the version you desire here
-      - image: broadinstitute/womtool:71
+      - image: broadinstitute/womtool:84
         entrypoint: /bin/bash
     working_directory: ~/palantir-workflows
     environment: WOMTOOL_JAR=/app/womtool.jar
@@ -15,7 +15,7 @@ commands:
   get-cromwell-jar:
     description: "Download cromwell jar"
     steps:
-      - run: wget https://github.com/broadinstitute/cromwell/releases/download/78/cromwell-78.jar
+      - run: wget https://github.com/broadinstitute/cromwell/releases/download/84/cromwell-84.jar
 
   install-make:
     description: "Install make"
@@ -42,7 +42,7 @@ jobs:
     machine:
       image: ubuntu-2004:current
     environment:
-      CROMWELL_JAR=/home/circleci/project/cromwell-78.jar
+      CROMWELL_JAR=/home/circleci/project/cromwell-84.jar
     steps:
       - checkout
       - get-cromwell-jar

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -105,3 +105,6 @@ workflows:
   - name: ExtractSingleSampleVCFFromCallset
     subclass: WDL
     primaryDescriptorPath: /Utilities/WDLs/ExtractSampleFromVCF.wdl
+  - name: MatchFingerprints
+    subclass: WDL
+    primaryDescriptorPath: /Utilities/WDLs/MatchFingerprints.wdl

--- a/Utilities/WDLs/MatchFingerprints.wdl
+++ b/Utilities/WDLs/MatchFingerprints.wdl
@@ -1,0 +1,120 @@
+version 1.0
+
+workflow MatchFingerprints {
+    input {
+        Array[File] input_files
+        Array[File] reference_files
+
+        File haplotype_map
+
+        Boolean check_all_file_pairs = true
+        Boolean fail_on_mismatch = false
+        Boolean check_only_matching_sample_names = false
+
+        String crosscheck_by = "FILE"    # Or: READGROUP, LIBRARY, SAMPLE
+        Float lod_threshold = -5
+    }
+
+    if (check_all_file_pairs) {
+        scatter (pair in cross(input_files, reference_files)) {
+            call CheckFingerprints as CheckAllFingerprints {
+                input:
+                    input_file=pair.left,
+                    reference_file=pair.right,
+                    haplotype_map=haplotype_map,
+                    fail_on_mismatch=fail_on_mismatch,
+                    check_only_matching_sample_names=check_only_matching_sample_names,
+                    crosscheck_by=crosscheck_by,
+                    lod_threshold=lod_threshold
+            }
+        }
+    }
+
+    if (!check_all_file_pairs) {
+        scatter (pair in zip(input_files, reference_files)) {
+            call CheckFingerprints as CheckCorrespondingFingerprints {
+                input:
+                    input_file=pair.left,
+                    reference_file=pair.right,
+                    haplotype_map=haplotype_map,
+                    fail_on_mismatch=fail_on_mismatch,
+                    check_only_matching_sample_names=check_only_matching_sample_names,
+                    crosscheck_by=crosscheck_by,
+                    lod_threshold=lod_threshold
+            }
+        }
+    }
+
+    # Collect all the matched pairs detected with GATK
+    scatter (matched_pair in select_first([CheckAllFingerprints.sample_pair, CheckCorrespondingFingerprints.sample_pair])) {
+        if (matched_pair.right) {
+            Pair[File, File] matched_pairs = matched_pair.left
+        }
+    }
+
+    output {
+        Array[File] fingerprint_files = select_first([CheckAllFingerprints.fingerprint_file, CheckCorrespondingFingerprints.fingerprint_file])
+        Array[Pair[File, File]] matched_pairs = select_all(matched_pairs)
+    }
+}
+
+task CheckFingerprints {
+    input {
+        File input_file
+        File reference_file
+
+        File haplotype_map
+        Boolean fail_on_mismatch
+        Boolean check_only_matching_sample_names
+
+        String crosscheck_by
+        Float lod_threshold
+
+        String output_name = "output"
+        String gatk_tag = "4.4.0.0"
+    }
+
+    String crosscheck_mode = if check_only_matching_sample_names then "CHECK_SAME_SAMPLE" else "CHECK_ALL_OTHERS"
+
+    command <<<
+        set -xueo pipefail
+
+        # Allow "UNEXPECTED_MATCH" at this stage using exit code 0 arg; otherwise causes exit code 1
+        gatk CrosscheckFingerprints \
+            -I ~{input_file} \
+            -SI ~{reference_file} \
+            -H ~{haplotype_map} \
+            -O "~{output_name}.txt" \
+            -LOD ~{lod_threshold} \
+            --EXIT_CODE_WHEN_MISMATCH 0 \
+            --CROSSCHECK_MODE ~{crosscheck_mode} \
+            --CROSSCHECK_BY ~{crosscheck_by}
+
+        # Check if any of the comparisons performed are classified as a MATCH
+        if [ $(grep -v '#' "~{output_name}.txt" | awk '{print $3}' | grep "_MATCH" | wc -l) -gt 0 ];
+        then
+            echo "true" > result.txt
+        else
+            if [ "~{fail_on_mismatch}" = true ];
+            then
+                exit 1
+            else
+                echo "false" > result.txt
+            fi
+        fi
+
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-gatk/gatk:" + gatk_tag
+        preemptible: 2
+        disks: "local-disk " + ceil(size(input_file, "GB") + size(reference_file, "GB") + 20) + " HDD"
+        memory: 8 + " GB"
+    }
+
+    output {
+        Boolean contains_match = read_boolean("result.txt")
+        File fingerprint_file = "~{output_name}.txt"
+        Pair[Pair[File, File], Boolean] sample_pair = ((input_file, reference_file), contains_match)
+    }
+}

--- a/Utilities/WDLs/README.md
+++ b/Utilities/WDLs/README.md
@@ -5,8 +5,10 @@ This directory contains a collection of miscellaneous WDLs useful for some small
 * [CollectBenchmarkSucceeded](#collectbenchmarksucceeded)
 * [CreateIGVSession](#createigvsession)
 * [Dipcall](#dipcall)
-* [IndexCramOrBam](#indexcramorbam)
 * [DownsampleAndCollectCoverage](#downsampleandcollectcoverage)
+* [IndexCramOrBam](#indexcramorbam)
+* [MatchFingerprints](#matchfingerprints)
+
 
 ## CollectBenchmarkSucceeded
 
@@ -23,6 +25,7 @@ the successful outputs and aggregate them into one .csv, similar to the last tas
   in Terra, then this should be `<my_project>` as a string.
 * `workspace_name`: specific name for your workspace, e.g. `<my_workspace>` in the last example.
 * `submission_id`: the submission id for the `FindSamplesAndBenchmark` run, found from the "Job History" tab.
+
 
 ## CreateIGVSession
 
@@ -42,6 +45,7 @@ you might want to visualize together for analysis or debugging.
 * `reference`: reference to use in IGV; must be either a `.fasta` file or one of the values: "hg38" or "hg19".
 * `output_name`: (default = "igv_session") name for the output .xml file.
 
+
 ## Dipcall
 
 ### Summary
@@ -60,6 +64,37 @@ when appropriate. Some data cleaning and indexing of the output VCF is also perf
 * `custom_PAR_bed`: bed file denoting pseudoautosomal (PAR) regions for your reference
 * `sample_name`: name to put for your sample in final output VCF
 * `referenceIsHS38`: set true (default) if using hg38 reference
+
+
+## DownsampleAndCollectCoverage
+
+### Summary
+
+The idea of this WDL is to do everything you need for a standard downsampling experiment. It takes in either CRAM or BAM files and downsamples them either according to a defined downsampling ratio or to a desired target coverage. If no downsampling ratio is defined then it will run `ColectWgsMetrics` to get the original mean coverage and determine the downsampling ratio based on that coverage and the desired target coverage. After downsampling using `DownsampleSam` the workflow will run `CollectWgsMetrics` once more and output the mean coverage of the downsampled CRAM (or BAM) file. This provides feedback with respect to the target coverage, because downsampling is always associated with some uncertainty. If `fail_if_below_coverage` is set, the workflow will fail if that downsampled mean coverage is below the provided threshold.
+
+### Inputs
+* `File input_cram`: Input BAM or CRAM
+* `File input_cram_index`: Index file for input BAM or CRAM
+* `File ref_fasta`: Reference FASTA
+* `File ref_fasta_index`: Reference FASTA index
+* `Float? downsample_probability`: Downsampling ratio. If not provided, the ratio will be determined based on the `target_coverage`.
+* `Float? fail_if_below_coverage`: Fail the workflow if the downsampled mean coverage is below this value.
+* `Float? target_coverage`: Target mean coverage for the downsampled CRAM file. **In order to use this input, do not provide `downsample_probability`, otherwise, that value will be used for downsampling.**
+* `File? coverage_intervals`: If provided, the output downsampled mean coverage will be calculated based on these intervals. Additionally, these intervals will be used to calculate the original coverage if `target_coverage` is used.
+* `String downsample_strategy = "ConstantMemory"`: See [DownsampleSam documentation](https://gatk.broadinstitute.org/hc/en-us/articles/13832708637467-DownsampleSam-Picard-).
+* `Int read_length = 150`: See [CollectWgsMetrics documentation](https://gatk.broadinstitute.org/hc/en-us/articles/13832707851035-CollectWgsMetrics-Picard-).
+* `Boolean use_fast_algorithm = true`: See [CollectWgsMetrics documentation](https://gatk.broadinstitute.org/hc/en-us/articles/13832707851035-CollectWgsMetrics-Picard-).
+* `Boolean output_bam_instead_of_cram`: If set to true, the workflow will produce a downsampled output BAM (the default is CRAM).
+* `String docker = "us.gcr.io/broad-gatk/gatk:4.4.0.0"`: Docker to use for both CollectWgsMetrics and DownsampleSam
+* `File? picard_jar_override`: If provided, a Picard JAR file to use for both CollectWgsMetrics and DownsampleSam instead of the `gatk` command.
+* `Int preemptible = 1`: Preemptible attempts
+
+### Outputs
+* `File downsampled_cram`: Downsampled CRAM
+* `File downsampled_cram_index`: Downsampled CRAM index
+* `Float downsampled_mean_coverage`: Mean coverage over the `coverage_intervals` (or the whole genome if not provided) for the downsampled CRAM file
+* `File downsampled_wgs_metrics`: Output of CollectWgsMetrics run on the downsampled file
+* `Float? original_mean_coverage`: The original mean coverage over the `coverage_intervals` (or the whole genome if not provided) of the input CRAM file, if `target_coverage` was used
 
 
 ## IndexCramOrBam
@@ -86,32 +121,22 @@ If labels are provided, they will be returned in the new order of the `bed_files
 * `bed_labels`: a list of labels for the `.bed` files corresponding to the user inputs, or the basename of the input files if the user did not provide any labels. Note the order may have changed, but the position of a label corresponds to the position of the file in `bed_files`.
 
 
-## DownsampleAndCollectCoverage
+## MatchFingerprints
 
 ### Summary
 
-The idea of this WDL is to do everything you need for a standard downsampling experiment. It takes in either CRAM or BAM files and downsamples them either according to a defined downsampling ratio or to a desired target coverage. If no downsampling ratio is defined then it will run `ColectWgsMetrics` to get the original mean coverage and determine the downsampling ratio based on that coverage and the desired target coverage. After downsampling using `DownsampleSam` the workflow will run `CollectWgsMetrics` once more and output the mean coverage of the downsampled CRAM (or BAM) file. This provides feedback with respect to the target coverage, because downsampling is always associated with some uncertainty. If `fail_if_below_coverage` is set, the workflow will fail if that downsampled mean coverage is below the provided threshold.
+This WDL allows you to check fingerprints across two sets of files, and match them. There is an option to fail if files don't match fingerprints, allowing you to use this as a safety check on workflows that have paired files that must have matching samples. Alternatively, the WDL also has functionality to support finding matches across two batches, which can then be used downstream.
 
-### Inputs 
-* `File input_cram`: Input BAM or CRAM
-* `File input_cram_index`: Index file for input BAM or CRAM
-* `File ref_fasta`: Reference FASTA
-* `File ref_fasta_index`: Reference FASTA index
-* `Float? downsample_probability`: Downsampling ratio. If not provided, the ratio will be determined based on the `target_coverage`.
-* `Float? fail_if_below_coverage`: Fail the workflow if the downsampled mean coverage is below this value.
-* `Float? target_coverage`: Target mean coverage for the downsampled CRAM file. **In order to use this input, do not provide `downsample_probability`, otherwise, that value will be used for downsampling.** 
-* `File? coverage_intervals`: If provided, the output downsampled mean coverage will be calculated based on these intervals. Additionally, these intervals will be used to calculate the original coverage if `target_coverage` is used.
-* `String downsample_strategy = "ConstantMemory"`: See [DownsampleSam documentation](https://gatk.broadinstitute.org/hc/en-us/articles/13832708637467-DownsampleSam-Picard-).
-* `Int read_length = 150`: See [CollectWgsMetrics documentation](https://gatk.broadinstitute.org/hc/en-us/articles/13832707851035-CollectWgsMetrics-Picard-).
-* `Boolean use_fast_algorithm = true`: See [CollectWgsMetrics documentation](https://gatk.broadinstitute.org/hc/en-us/articles/13832707851035-CollectWgsMetrics-Picard-).
-* `Boolean output_bam_instead_of_cram`: If set to true, the workflow will produce a downsampled output BAM (the default is CRAM).
-* `String docker = "us.gcr.io/broad-gatk/gatk:4.4.0.0"`: Docker to use for both CollectWgsMetrics and DownsampleSam
-* `File? picard_jar_override`: If provided, a Picard JAR file to use for both CollectWgsMetrics and DownsampleSam instead of the `gatk` command.
-* `Int preemptible = 1`: Preemptible attempts
+### Inputs
+* `input_files`: a list of files to check the fingerprints of
+* `reference_files`: a list of files to use as a baseline when comparing fingerprints
+* `haplotype_map`: a haplotype map file used for Picard's `CrosscheckFingerprints` tool; see the docs [here](https://gatk.broadinstitute.org/hc/en-us/articles/13832766699291-CrosscheckFingerprints-Picard)
+* `check_all_file_pairs`: (default: `true`) fingerprints pairs across *all* `input_file` and `reference_file` pairs when toggled `true`; otherwise fingerprints are only checked across files with the same index, and input lists must have the same length
+* `fail_on_mismatch`: (default: `false`) toggle `true` to force your workflow to fail when fingerprinting fails to provide a "MATCH" for each comparison done; note for an individual comparison between `file1` and `file2`, if there are multiple samples/read groups/etc. being compared based on the mode selected, this check will pass (the workflow will NOT fail) if the resulting fingerprint summary file has *at least one* entry with a "MATCH"
+* `check_only_matching_sample_names`: (default: `false`) toggle `true` to force the fingerprint comparison to have the same sample name across the files; required `crosscheck_by` be set to `SAMPLE`
+* `crosscheck_by`: (default: `FILE`) controls at which level fingerprinting can happen; must be either `FILE`, `SAMPLE`, `LIBRARY`, or `READGROUP`
+* `lod_threshold`: (default: -5) if the LOD fingerprinting score is less than this value, then the pair is a mismatch, and if it is greater than the negative of this value, then the pair is labeled a match
 
 ### Outputs
-* `File downsampled_cram`: Downsampled CRAM
-* `File downsampled_cram_index`: Downsampled CRAM index
-* `Float downsampled_mean_coverage`: Mean coverage over the `coverage_intervals` (or the whole genome if not provided) for the downsampled CRAM file
-* `File downsampled_wgs_metrics`: Output of CollectWgsMetrics run on the downsampled file
-* `Float? original_mean_coverage`: The original mean coverage over the `coverage_intervals` (or the whole genome if not provided) of the input CRAM file, if `target_coverage` was used
+* `fingerprint_files`: a list of files output by `CrosscheckFingerprints` for each comparison made by the tool
+* `matched_pairs`: a list of pairs of files that were detected to be matches using the set criteria; this list can be used/iterated over in other workflows to only act on pairs of files that are considered fingerprint matches

--- a/Utilities/WDLs/README.md
+++ b/Utilities/WDLs/README.md
@@ -129,7 +129,9 @@ This WDL allows you to check fingerprints across two sets of files, and match th
 
 ### Inputs
 * `input_files`: a list of files to check the fingerprints of
+* `input_indices`: list of corresponding index files for `input_files`
 * `reference_files`: a list of files to use as a baseline when comparing fingerprints
+* `reference_indices`: list of corresponding index files for `reference_files`
 * `haplotype_map`: a haplotype map file used for Picard's `CrosscheckFingerprints` tool; see the docs [here](https://gatk.broadinstitute.org/hc/en-us/articles/13832766699291-CrosscheckFingerprints-Picard)
 * `check_all_file_pairs`: (default: `true`) fingerprints pairs across *all* `input_file` and `reference_file` pairs when toggled `true`; otherwise fingerprints are only checked across files with the same index, and input lists must have the same length
 * `fail_on_mismatch`: (default: `false`) toggle `true` to force your workflow to fail when fingerprinting fails to provide a "MATCH" for each comparison done; note for an individual comparison between `file1` and `file2`, if there are multiple samples/read groups/etc. being compared based on the mode selected, this check will pass (the workflow will NOT fail) if the resulting fingerprint summary file has *at least one* entry with a "MATCH"


### PR DESCRIPTION
This PR adds a utility for handling various applications of fingerprinting. In particular, it should have functionality to perform the following:
* Act as a failsafe, allowing you to fail workflows when paired files don't match fingerprinting as expected;
* Allow you to match across all pairs in two lists of files, for when you might not be particularly sure of how to match up files due to known/suspected sample swaps, easy benchmarking truth-matching, or other cases;
* Give users the ability to toggle a few specific details, like forcing sample names to match in files, toggling the threshold for fingerprinting matches, etc.

It should be simple to drop into WDLs which require matched files for the same samples (like benchmarking query vs truth data), and use the resulting `matched_pairs` output of the task to ensure you only act on fingerprint-matched pairs of files. See the README edits for some more details.