### PR TITLE
Update CleanSVs and some typos in BenchmarkSVs

### DIFF
--- a/BenchmarkSVs/BenchmarkSVs.wdl
+++ b/BenchmarkSVs/BenchmarkSVs.wdl
@@ -289,7 +289,7 @@ task SubsetEvaluation {
 
         # Subset input VCF to only sites which intersect evaluation regions over pct overlap threshold
         bcftools view -h ~{input_vcf} > header.txt
-        bedtools intersect -a ~{input_vcf} -b ~{evaluation_bed} ~{"-f" + evaluation_pct} -u > variants.vcf
+        bedtools intersect -a ~{input_vcf} -b ~{evaluation_bed} ~{"-f " + evaluation_pct} -u > variants.vcf
 
         cat header.txt variants.vcf | bcftools view -o output.vcf.gz -
         bcftools index -t output.vcf.gz

--- a/BenchmarkSVs/BenchmarkSVs.wdl
+++ b/BenchmarkSVs/BenchmarkSVs.wdl
@@ -455,7 +455,7 @@ task CollectQcMetrics {
 
         # Bin AF
         AF_Bin_cutoffs = [~{default="" sep=", " af_bin_cutoffs}]
-        AF_Bin_start = [f'< {AF_Bin_cutoffs[0]}%']
+        AF_Bin_start = [f'<{AF_Bin_cutoffs[0]}%']
         AF_Bins_middle = [f'{AF_Bin_cutoffs[i]}-{AF_Bin_cutoffs[i+1]}%' for i in range(len(AF_Bin_cutoffs)-1)]
         AF_Bin_end = [f'>{AF_Bin_cutoffs[-1]}%']
         AF_Bins = AF_Bin_start + AF_Bins_middle + AF_Bin_end

--- a/BenchmarkSVs/CleanSVs.wdl
+++ b/BenchmarkSVs/CleanSVs.wdl
@@ -208,6 +208,8 @@ task NormalizeAndClean {
                         if ((len(record.filter.values()) == 0) and ('~{normalize_missing_filter_to_pass}' == 'true')) or ('~{strip_filters}' == 'true'):
                             record.filter.clear()
                             record.filter.add('PASS')
+                        ref = record.alleles[0]
+                        alt = record.alleles[1]
                         if (np.abs(len(ref) - len(alt)) >= ~{min_size}) or (record.info['SVLEN'] >= ~{min_size}):
                             if record.info['SVLEN'] > 0:    # sniffles actually will write variants with abstract alleles SVLEN = 0, which causes problem in Wittyer...
                                 output_vcf.write(record)

--- a/BenchmarkSVs/README.md
+++ b/BenchmarkSVs/README.md
@@ -106,6 +106,7 @@ Some tools are particular about the format required to process SV VCFs, like Wit
 - `min_size` - (default = 50) minimum (absolute value) size of variants to keep
 - `split_MA` - (default = true) split multiallelic sites into biallelic sites
 - `add_annotations` - (default = true) add annotations like `END`, etc. required by the benchmarking pipeline if not already included
+- `normalize_and_clean` - (default = true) remove `SVTYPE`s outside specified list, and convert missing filter to `PASS` optionally; also includes option to set min length bound and replace all filters with `PASS` in task inputs
 - `convert_to_abstract` - (default = true) convert SVs represented by long sequences into variants with symbolic alleles (`INS` or `DEL` only)
 
 ### Outputs


### PR DESCRIPTION
This short PR does two things:
- Refactors some of CleanSVs to separate certain cleaning steps to a separate optional step, to allow one to get the same filtering benefits without needing to convert to abstract alleles.
- Fixes some minor typos in BenchmarkSVs

The docs for CleanSVs is updated accordingly.