### PR TITLE
Changing GLIMPSE to localize using samtools

### DIFF
--- a/GlimpseImputationPipeline/Glimpse2Imputation.wdl
+++ b/GlimpseImputationPipeline/Glimpse2Imputation.wdl
@@ -180,10 +180,6 @@ task GlimpsePhase {
             echo "Processed CRAM ${i}: ${cram_paths[$i]} -> cram${i}.cram"
         done
 
-        for i in "${!cram_paths[@]}" ; do
-            echo -e "${cram_paths[$i]} ${sample_ids[$i]}" >> crams.list
-        done
-
         cmd="/bin/GLIMPSE2_phase \
         ~{"--input-gl " + input_vcf} \
         --reference ~{reference_chunk} \

--- a/GlimpseImputationPipeline/Glimpse2Imputation.wdl
+++ b/GlimpseImputationPipeline/Glimpse2Imputation.wdl
@@ -25,7 +25,7 @@ workflow Glimpse2Imputation {
         Boolean collect_qc_metrics = true
         
         Int preemptible = 9
-        String docker = "us.gcr.io/broad-dsde-methods/glimpse:odelaneau_e0b9b56"
+        String docker = "us.gcr.io/broad-dsde-methods/glimpse:odelaneau_f310862"
         String docker_extract_num_sites_from_reference_chunk = "us.gcr.io/broad-dsde-methods/glimpse_extract_num_sites_from_reference_chunks:michaelgatzen_edc7f3a"
         Int cpu_ligate = 4
         Int mem_gb_ligate = 4
@@ -159,7 +159,7 @@ task GlimpsePhase {
         set -euo pipefail
 
         export GCS_OAUTH_TOKEN=$(/root/google-cloud-sdk/bin/gcloud auth application-default print-access-token)
-        
+
         seq_cache_populate.pl -root ./ref/cache ~{fasta}
         export REF_PATH=:
         export REF_CACHE=./ref/cache/%2s/%2s/%s

--- a/GlimpseImputationPipeline/Glimpse2Imputation.wdl
+++ b/GlimpseImputationPipeline/Glimpse2Imputation.wdl
@@ -159,18 +159,26 @@ task GlimpsePhase {
         set -euo pipefail
 
         export GCS_OAUTH_TOKEN=$(/root/google-cloud-sdk/bin/gcloud auth application-default print-access-token)
+        
+        seq_cache_populate.pl -root ./ref/cache ~{fasta}
+        export REF_PATH=:
+        export REF_CACHE=./ref/cache/%2s/%2s/%s
 
         ~{"bash " + monitoring_script + " > monitoring.log &"}
 
         cram_paths=( ~{sep=" " crams} )
+        cram_index_paths=( ~{sep=" " cram_indices} )
         sample_ids=( ~{sep=" " sample_ids} )
 
-        duplicate_cram_filenames=$(printf "%s\n" "${cram_paths[@]}" | xargs -I {} basename {} | uniq -d)
-        if [ ! -z "$duplicate_cram_filenames" ]; then
-            echo "ERROR: The input CRAMs contain multiple files with the same basename, which leads to an error due to the way that htslib is implemented. Duplicate filenames:"
-            printf "%s\n" "${duplicate_cram_filenames[@]}"
-            exit 1
-        fi
+        chunk_region=$(echo "~{reference_chunk}"|sed 's/^.*chr/chr/'|sed 's/\.bin//'|sed 's/_/:/1'|sed 's/_/-/1')
+
+        echo "Region for CRAM extraction: ${chunk_region}"
+        for i in "${!cram_paths[@]}" ; do
+            samtools view -h -C -X -T ~{fasta} -o cram${i}.cram "${cram_paths[$i]}" "${cram_index_paths[$i]}" ${chunk_region}
+            samtools index cram${i}.cram
+            echo -e "cram${i}.cram ${sample_ids[$i]}" >> crams.list
+            echo "Processed CRAM ${i}: ${cram_paths[$i]} -> cram${i}.cram"
+        done
 
         for i in "${!cram_paths[@]}" ; do
             echo -e "${cram_paths[$i]} ${sample_ids[$i]}" >> crams.list

--- a/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl
+++ b/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl
@@ -31,6 +31,7 @@ workflow Glimpse2ImputationInBatches {
         String? docker_extract_num_sites_from_reference_chunk
         Int? cpu_ligate
         Int? mem_gb_ligate
+        Int? mem_gb_merge
         File? monitoring_script
 
         String? docker_extract_annotations
@@ -88,6 +89,7 @@ workflow Glimpse2ImputationInBatches {
             imputed_vcf_indices = Glimpse2Imputation.imputed_vcf_index,
             output_basename = output_basename,
             qc_metrics = qc_metrics,
+            mem_gb_merge = mem_gb_merge,
             docker_extract_annotations = docker_extract_annotations,
             docker_count_samples = docker_count_samples,
             docker_merge = docker_merge

--- a/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl
+++ b/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl
@@ -12,6 +12,8 @@ workflow Glimpse2MergeBatches {
         String docker_extract_annotations = "us.gcr.io/broad-gatk/gatk:4.3.0.0"
         String docker_count_samples = "us.gcr.io/broad-dsde-methods/bcftools:v1.3"
         String docker_merge = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
+
+        Int mem_gb_merge = 16
     }
 
     if (defined(qc_metrics) && (length(imputed_vcfs) != length(select_first([qc_metrics, []])))) {
@@ -46,6 +48,7 @@ workflow Glimpse2MergeBatches {
                 annotations = ExtractAnnotations.annotations,
                 num_samples = CountSamples.num_samples,
                 output_basename = output_basename,
+                mem_gb = mem_gb_merge,
                 docker_merge = docker_merge
         }
     }
@@ -156,7 +159,7 @@ task MergeAndRecomputeAndAnnotate {
 
         String docker_merge
         Int disk_size_gb = ceil(2.2 * size(imputed_vcfs, "GiB") + 50)
-        Int mem_gb = 2
+        Int mem_gb
         Int cpu = 2
         Int preemptible = 1
     }

--- a/GlimpseImputationPipeline/glimpse_docker/Dockerfile
+++ b/GlimpseImputationPipeline/glimpse_docker/Dockerfile
@@ -17,6 +17,18 @@ make install && \
 cd .. && \
 rm -r bcftools-1.16
 
+# Download and build samtools
+RUN wget https://github.com/samtools/samtools/releases/download/1.16/samtools-1.16.tar.bz2 && \
+tar -xf samtools-1.16.tar.bz2 && \
+rm samtools-1.16.tar.bz2 && \
+cd samtools-1.16 && \
+autoheader && \
+autoconf && \
+./configure --enable-libcurl --without-curses && \
+make install && \
+cd .. && \
+rm -r samtools-1.16
+
 # Download picard (for updating sequence dictionary)
 RUN wget https://github.com/broadinstitute/picard/releases/download/2.26.11/picard.jar && \
 mv picard.jar /

--- a/GlimpseImputationPipeline/glimpse_docker/build_base_and_extension_docker.sh
+++ b/GlimpseImputationPipeline/glimpse_docker/build_base_and_extension_docker.sh
@@ -22,7 +22,7 @@ Available options:
 -h, --help      Print this help and exit.
 -p, --push      If set, push image.
 -y, --yes       If set, don't ask for confirmation.
--t, --tag       Tag for the newly created docker image. Suggestion: Use {github_namespace}_{commit_id} as the version tag, e.g. odelaneau_e0b9b56.
+-t, --tag       Tag for the newly created docker image. Suggestion: Use {github_namespace}_{commit_id} as the version tag. E.g. us.gcr.io/broad-dsde-methods/glimpse:odelaneau_e0b9b56.
 -r, --repo      Repo URL for the GLIMPSE2 base image (e.g. https://github.com/odelaneau/GLIMPSE.git).
 -b, --branch    Branch name for the GLIMPSE2 base image (e.g. master).
 EOF


### PR DESCRIPTION
GLIMPSE2's built-in streaming does not work if the input CRAM indices are in different (cloud) paths than their respective CRAM files. Thus, we need to localize the input CRAMs to a local directory. We can do that using `samtools view`, only extracting the region of the current chunk that's being processed.