### PR TITLE
Remove cram localization in GLIMPSE phase

### DIFF
--- a/GlimpseImputationPipeline/Glimpse2Imputation.wdl
+++ b/GlimpseImputationPipeline/Glimpse2Imputation.wdl
@@ -167,7 +167,11 @@ task GlimpsePhase {
         sample_ids=( ~{sep=" " sample_ids} )
 
         for i in "${!cram_paths[@]}" ; do
-            echo -e "${cram_paths[i]} ~{if defined(cram_indices) then '${cram_index_paths[i]} ' else ' '}${sample_ids[$i]}" >> crams.list
+            if [ "${#cram_paths[@]}" -eq "${#cram_index_paths[@]}" ]; then
+                echo -e "${cram_paths[i]} ${cram_index_paths[i]} ${sample_ids[$i]}" >> crams.list
+            else
+                echo -e "${cram_paths[i]} ${sample_ids[$i]}" >> crams.list
+            fi
         done
 
         cmd="/bin/GLIMPSE2_phase \

--- a/GlimpseImputationPipeline/Glimpse2Imputation.wdl
+++ b/GlimpseImputationPipeline/Glimpse2Imputation.wdl
@@ -25,7 +25,7 @@ workflow Glimpse2Imputation {
         Boolean collect_qc_metrics = true
         
         Int preemptible = 9
-        String docker = "us.gcr.io/broad-dsde-methods/glimpse:odelaneau_f310862"
+        String docker = "us.gcr.io/broad-dsde-methods/ckachulis/glimpse_for_wdl_pipeline:specify_cram "
         String docker_extract_num_sites_from_reference_chunk = "us.gcr.io/broad-dsde-methods/glimpse_extract_num_sites_from_reference_chunks:michaelgatzen_edc7f3a"
         Int cpu_ligate = 4
         Int mem_gb_ligate = 4
@@ -160,24 +160,14 @@ task GlimpsePhase {
 
         export GCS_OAUTH_TOKEN=$(/root/google-cloud-sdk/bin/gcloud auth application-default print-access-token)
 
-        seq_cache_populate.pl -root ./ref/cache ~{fasta}
-        export REF_PATH=:
-        export REF_CACHE=./ref/cache/%2s/%2s/%s
-
         ~{"bash " + monitoring_script + " > monitoring.log &"}
 
         cram_paths=( ~{sep=" " crams} )
         cram_index_paths=( ~{sep=" " cram_indices} )
         sample_ids=( ~{sep=" " sample_ids} )
 
-        chunk_region=$(echo "~{reference_chunk}"|sed 's/^.*chr/chr/'|sed 's/\.bin//'|sed 's/_/:/1'|sed 's/_/-/1')
-
-        echo "Region for CRAM extraction: ${chunk_region}"
         for i in "${!cram_paths[@]}" ; do
-            samtools view -h -C -X -T ~{fasta} -o cram${i}.cram "${cram_paths[$i]}" "${cram_index_paths[$i]}" ${chunk_region}
-            samtools index cram${i}.cram
-            echo -e "cram${i}.cram ${sample_ids[$i]}" >> crams.list
-            echo "Processed CRAM ${i}: ${cram_paths[$i]} -> cram${i}.cram"
+            echo -e "${cram_paths[i]} ~{if defined(cram_indices) then '${cram_index_paths[i]} ' else ' '}${sample_ids[$i]}" >> crams.list
         done
 
         cmd="/bin/GLIMPSE2_phase \

--- a/GlimpseImputationPipeline/Glimpse2Imputation.wdl
+++ b/GlimpseImputationPipeline/Glimpse2Imputation.wdl
@@ -25,7 +25,7 @@ workflow Glimpse2Imputation {
         Boolean collect_qc_metrics = true
         
         Int preemptible = 9
-        String docker = "us.gcr.io/broad-dsde-methods/ckachulis/glimpse_for_wdl_pipeline:specify_cram "
+        String docker = "us.gcr.io/broad-dsde-methods/ckachulis/glimpse_for_wdl_pipeline:specify_cram_index"
         String docker_extract_num_sites_from_reference_chunk = "us.gcr.io/broad-dsde-methods/glimpse_extract_num_sites_from_reference_chunks:michaelgatzen_edc7f3a"
         Int cpu_ligate = 4
         Int mem_gb_ligate = 4

--- a/GlimpseImputationPipeline/glimpse_docker/build_base_and_extension_docker.sh
+++ b/GlimpseImputationPipeline/glimpse_docker/build_base_and_extension_docker.sh
@@ -124,8 +124,8 @@ fi
 
 git clone $repo --branch $branch --single-branch ${script_dir}/glimpse_base
 
-docker build -t temp_glimpse_base ${script_dir}/glimpse_base
-docker build -t ${tag} ${script_dir}
+docker build --platform linux/amd64 -t temp_glimpse_base ${script_dir}/glimpse_base
+docker build --platform linux/amd64 -t ${tag} ${script_dir}
 
 if [ "$push" -eq "1" ]; then
     msg "Pushing docker image to ${tag}"


### PR DESCRIPTION
https://github.com/odelaneau/GLIMPSE/pull/208 allows cram index to be specified when running GLIMPSE, so that ref caching and partial cram localization are no longer necessary.