### PR TITLE
Hotfix: Update IGV xml writing docker to get benchmark tests passing

### DIFF
--- a/BenchmarkVCFs/BenchmarkVCFs.wdl
+++ b/BenchmarkVCFs/BenchmarkVCFs.wdl
@@ -1461,10 +1461,10 @@ task WriteXMLfile {
         Array[String] input_names_prefix = if defined(input_names) then prefix('-n ', select_first([input_names])) else []
     }
     command {
-        bash /usr/writeIGV.sh ~{reference_version} ~{sep=" " input_files} ~{sep=" " input_names_prefix}  > "~{file_name}.xml"
+        /usr/writeIGV.sh ~{reference_version} ~{sep=" " input_files} ~{sep=" " input_names_prefix}  > "~{file_name}.xml"
     }
     runtime {
-        docker: "quay.io/mduran/generate-igv-session_2:v1.0"
+        docker: "us-central1-docker.pkg.dev/broad-dsde-methods/hydro-gen-dockers/igv-xml:v1.0"
     }
     output {
         File igv_session = "${file_name}.xml"

--- a/BenchmarkVCFs/BenchmarkVCFs.wdl
+++ b/BenchmarkVCFs/BenchmarkVCFs.wdl
@@ -1464,7 +1464,7 @@ task WriteXMLfile {
         /usr/writeIGV.sh ~{reference_version} ~{sep=" " input_files} ~{sep=" " input_names_prefix}  > "~{file_name}.xml"
     }
     runtime {
-        docker: "us-central1-docker.pkg.dev/broad-dsde-methods/hydro-gen-dockers/igv-xml:v1.0"
+        docker: "us.gcr.io/broad-dsde-methods/igv-xml:v1.0"
     }
     output {
         File igv_session = "${file_name}.xml"

--- a/BenchmarkVCFs/CreateIGVSession.wdl
+++ b/BenchmarkVCFs/CreateIGVSession.wdl
@@ -31,7 +31,7 @@ task WriteXMLfile {
         /usr/writeIGV.sh ~{reference_version} ~{sep=" " input_files} ~{sep=" " input_names_prefix}  > "~{file_name}.xml"
     }
     runtime {
-        docker: "us-central1-docker.pkg.dev/broad-dsde-methods/hydro-gen-dockers/igv-xml:v1.0"
+        docker: "us.gcr.io/broad-dsde-methods/igv-xml:v1.0"
     }
     output {
         File igv_session = "${file_name}.xml"

--- a/BenchmarkVCFs/CreateIGVSession.wdl
+++ b/BenchmarkVCFs/CreateIGVSession.wdl
@@ -28,10 +28,10 @@ task WriteXMLfile {
         Array[String] input_names_prefix = if defined(input_names) then prefix('-n ', select_first([input_names])) else []
     }
     command {
-        bash /usr/writeIGV.sh ~{reference_version} ~{sep=" " input_files} ~{sep=" " input_names_prefix}  > "~{file_name}.xml"
+        /usr/writeIGV.sh ~{reference_version} ~{sep=" " input_files} ~{sep=" " input_names_prefix}  > "~{file_name}.xml"
     }
     runtime {
-        docker: "quay.io/mduran/generate-igv-session_2:v1.0"
+        docker: "us-central1-docker.pkg.dev/broad-dsde-methods/hydro-gen-dockers/igv-xml:v1.0"
     }
     output {
         File igv_session = "${file_name}.xml"

--- a/Utilities/Dockers/IGV-XML/Dockerfile
+++ b/Utilities/Dockers/IGV-XML/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:22.10
+
+COPY writeIGV.sh /usr/writeIGV.sh

--- a/Utilities/Dockers/IGV-XML/writeIGV.sh
+++ b/Utilities/Dockers/IGV-XML/writeIGV.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+ref=$1
+echo "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"
+echo "<Session genome=\""$ref"\" hasGeneTrack=\"true\" hasSequenceTrack=\"true\" locus=\"All\" nextAutoscaleGroup=\"4\" path=\"\" version=\"8\">"
+echo -e "\t<Resources>"
+
+NAMES=""
+FILES=""
+
+while [ "$2" != "" ]; do
+	case "$2" in 
+		-n ) shift
+			 NAMES="$NAMES $2"
+			 ;;
+		* )  FILES="$FILES $2";;
+	esac
+	shift
+done
+
+names=($NAMES)
+files=($FILES)
+
+#if names is empty
+if [ -z "$names" ]; then
+    for ((i=0;i<${#files[@]};++i)); do
+    	echo -e "\t\t<Resource path=\""${files[i]}"\"/>" 
+	done    
+else
+    for ((i=0;i<${#files[@]};++i)); do
+    	echo -e "\t\t<Resource path=\""${files[i]}"\" name=\""${names[i]}"\"/>" 
+	done  
+fi
+
+echo -e "\t</Resources>"
+echo "</Session>"
+


### PR DESCRIPTION
IGV xml writing currently uses a very old docker image hosted on Maddie's personal quay.io account.  This has recently led to test failures due to the deprecation of old docker image manifest schemes and (presumably) an upgrade in the version of docker run on cicle-ci machines (see https://docs.docker.com/engine/deprecated/#pushing-and-pulling-with-image-manifest-v2-schema-1).  

I could not find a dockerfile for this docker anywhere, or even a copy of the `writeIGV.sh` script.  The references I could find all pointed to a google bucket that doesn't seem to exist anymore.  So I copied the script out of the old docker, and added into this repo, and created a new docker file and image for it.  I pushed the image to  `us-central1-docker.pkg.dev/broad-dsde-methods/hydro-gen-dockers/igv-xml:v1.0` so we will have better control of it moving forward. 