### PR TITLE
Fix version parsing errors when building with pip

### DIFF
--- a/ImputationPipeline/CreateAggregationSets/pyproject.toml
+++ b/ImputationPipeline/CreateAggregationSets/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "ImputationPipeline/CreateAggregationSets/_version.py"
 root = "../../"
+git_describe_command = ['git', 'describe', '--dirty', '--tags', '--long', '--match', 'v[0-9]*']
 
 [project]
 name = "CreateAggregationSets"

--- a/ImputationPipeline/ManualQCPRS/pyproject.toml
+++ b/ImputationPipeline/ManualQCPRS/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "ImputationPipeline/ManualQCPRS/_version.py"
 root = "../../"
+git_describe_command = ['git', 'describe', '--dirty', '--tags', '--long', '--match', 'v[0-9]*']
 
 [project]
 name = "ManualQCPRS"


### PR DESCRIPTION
when building ManualCQPRS or CreateAggregationSets with pip, if new tags are added which match the git describe command but do not match the versioning regex, pip will fail.  To fix this, I changed the git_describe_command to match tags for the for `v[0-9]*`.  I don't think this is not a perfect fix, as there are still probably edge cases that could cause failure, but in practicality given the tagging and versioning practices we use, I think it is good enough.