### PR TITLE
Update BenchmarkSVs workflow(s) with some new features

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -144,3 +144,9 @@ workflows:
   - name: ScoreBGE
     subclass: WDL
     primaryDescriptorPath: /ImputationPipeline/ScoreBGE/ScoreBGE.wdl
+  - name: BenchmarkSVs
+    subclass: WDL
+    primaryDescriptorPath: /BenchmarkVCFs/BenchmarkSVs.wdl
+  - name: QcSVs
+    subclass: WDL
+    primaryDescriptorPath: /BenchmarkVCFs/QcSVs.wdl

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -146,7 +146,7 @@ workflows:
     primaryDescriptorPath: /ImputationPipeline/ScoreBGE/ScoreBGE.wdl
   - name: BenchmarkSVs
     subclass: WDL
-    primaryDescriptorPath: /BenchmarkVCFs/BenchmarkSVs.wdl
+    primaryDescriptorPath: /BenchmarkSVs/BenchmarkSVs.wdl
   - name: QcSVs
     subclass: WDL
-    primaryDescriptorPath: /BenchmarkVCFs/QcSVs.wdl
+    primaryDescriptorPath: /BenchmarkSVs/QcSVs.wdl

--- a/BenchmarkSVs/BenchmarkSVs.wdl
+++ b/BenchmarkSVs/BenchmarkSVs.wdl
@@ -352,6 +352,16 @@ task RunTruvari {
             mv tp-comp-filtered.bed tp-comp.bed
         fi
 
+        # Organize final outputs together
+        mkdir final_outputs
+        mv "${RESULTS_STEM}tp-base.vcf.gz" final_outputs/tp-base.vcf.gz
+        mv "${RESULTS_STEM}tp-base.vcf.gz.tbi" final_outputs/tp-base.vcf.gz.tbi
+        mv "${RESULTS_STEM}fn.vcf.gz" final_outputs/fn.vcf.gz
+        mv "${RESULTS_STEM}fn.vcf.gz.tbi" final_outputs/fn.vcf.gz.tbi
+        mv "${RESULTS_STEM}tp-comp.vcf.gz" final_outputs/tp-comp.vcf.gz
+        mv "${RESULTS_STEM}tp-comp.vcf.gz.tbi" final_outputs/tp-comp.vcf.gz.tbi
+        mv "${RESULTS_STEM}fp.vcf.gz" final_outputs/fp.vcf.gz
+        mv "${RESULTS_STEM}fp.vcf.gz.tbi" final_outputs/fp.vcf.gz.tbi
     >>>
 
     runtime {
@@ -362,14 +372,14 @@ task RunTruvari {
     }
 
     output {
-        File fn = "output_dir/fn.vcf.gz"
-        File fn_index = "output_dir/fn.vcf.gz.tbi"
-        File fp = "output_dir/fp.vcf.gz"
-        File fp_index = "output_dir/fp.vcf.gz.tbi"
-        File tp_base = "output_dir/tp-base.vcf.gz"
-        File tp_base_index = "output_dir/tp-base.vcf.gz.tbi"
-        File tp_comp = "output_dir/tp-comp.vcf.gz"
-        File tp_comp_index = "output_dir/tp-comp.vcf.gz.tbi"
+        File tp_base = "final_outputs/tp-base.vcf.gz"
+        File tp_base_index = "final_outputs/tp-base.vcf.gz.tbi"
+        File fn = "final_outputs/fn.vcf.gz"
+        File fn_index = "final_outputs/fn.vcf.gz.tbi"
+        File tp_comp = "final_outputs/tp-comp.vcf.gz"
+        File tp_comp_index = "final_outputs/tp-comp.vcf.gz.tbi"
+        File fp = "final_outputs/fp.vcf.gz"
+        File fp_index = "final_outputs/fp.vcf.gz.tbi"
 
         File base_table = "base.bed"
         File comp_table = "comp.bed"

--- a/BenchmarkSVs/BenchmarkSVs.wdl
+++ b/BenchmarkSVs/BenchmarkSVs.wdl
@@ -288,7 +288,7 @@ task RunTruvari {
             bcftools view -i 'FMT/BD="TP"' output_dir/anno-combined_result_query.vcf.gz -o output_dir/anno-comb-tp-comp.vcf.gz -Wtbi
             bcftools view -i 'FMT/BD="FP"' output_dir/anno-combined_result_query.vcf.gz -o output_dir/anno-comb-fp.vcf.gz -Wtbi
 
-            RESULTS_STEM="output_dir/phab_bench/anno-comb-"
+            RESULTS_STEM="output_dir/anno-comb-"
         fi
 
         # Use Python to collect the output results and compile across intervals into one table

--- a/BenchmarkSVs/BenchmarkSVs.wdl
+++ b/BenchmarkSVs/BenchmarkSVs.wdl
@@ -25,7 +25,7 @@ workflow BenchmarkSVs {
         File ref_fai
 
         File? evaluation_bed
-        Float? evaluation_pct    # Defaults to checking at least one base overlap evaluation_bed
+        Float? evaluation_pct    # Defaults to checking at least one base overlap evaluation_bed; between 0 and 1
 
         Array[File] bed_regions = []
         Array[String] bed_labels = []
@@ -205,7 +205,7 @@ task RunTruvari {
 
         ## Refine args
         Boolean harmonize_phased_variants = false    # Use truvari refine on phased inputs
-        String align = "mafft"
+        String aligner = "mafft"
 
         Boolean debug_mode = false
 
@@ -261,7 +261,7 @@ task RunTruvari {
                 --recount \
                 --use-region-coords \
                 --use-original-vcfs \
-                --align ~{align} \
+                --align ~{aligner} \
                 outputs
 
             truvari anno svinfo output_dir/phab_bench/tp-base.vcf.gz -o output_dir/phab_bench/anno-tp-base.vcf.gz
@@ -325,7 +325,7 @@ task RunTruvari {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/sv_docker:v1.0"
+        docker: "us.gcr.io/broad-dsde-methods/sv_docker:v1.1"
         disks: "local-disk " + runtimeAttributes.disk_size + " HDD"
         memory: runtimeAttributes.memory + " GB"
         cpu: runtimeAttributes.cpu

--- a/BenchmarkSVs/BenchmarkSVs.wdl
+++ b/BenchmarkSVs/BenchmarkSVs.wdl
@@ -268,7 +268,7 @@ task RunTruvari {
                 --use-region-coords \
                 --use-original-vcfs \
                 --align ~{aligner} \
-                outputs
+                output_dir
 
             truvari anno svinfo output_dir/phab_bench/tp-base.vcf.gz -o output_dir/phab_bench/anno-tp-base.vcf.gz
             bcftools index -t output_dir/phab_bench/anno-tp-base.vcf.gz

--- a/BenchmarkSVs/QcSVs.wdl
+++ b/BenchmarkSVs/QcSVs.wdl
@@ -1,0 +1,187 @@
+version 1.0
+
+import "https://raw.githubusercontent.com/broadinstitute/palantir-workflows/main/Utilities/WDLs/CreateIGVSession.wdl" as IGV
+import "tasks.wdl" as SV_tasks
+
+struct RuntimeAttributes {
+    Int disk_size
+    Int cpu
+    Int memory
+}
+
+workflow BenchmarkSVs {
+    input {
+        File vcf
+        File vcf_index
+
+        String? experiment
+
+        File ref_fasta
+        File ref_fai
+
+        File? evaluation_bed
+        Float? evaluation_pct    # Defaults to checking at least one base overlap evaluation_bed
+
+        Array[File] bed_regions = []
+        Array[String] bed_labels = []
+        Int breakpoint_padding = 20
+
+        Array[Int] svlen_bin_cutoffs = [100, 250, 1000, 2500, 10000, 25000]
+    }
+
+    # Subset to evaluation regions for remainder of analysis
+    if (defined(evaluation_bed)) {
+        call SV_tasks.SubsetEvaluation as SubsetComp {
+            input:
+                input_vcf=vcf,
+                input_vcf_index=vcf_index,
+                evaluation_bed=select_first([evaluation_bed]),
+                evaluation_pct=evaluation_pct
+        }
+    }
+
+    # Replace input files with subset versions
+    File subset_vcf = select_first([SubsetComp.output_vcf, vcf])
+    File subset_vcf_index = select_first([SubsetComp.output_vcf_index, vcf_index])
+
+    # QC Tasks
+    call CollectQcMetrics as QcMetrics {
+        input:
+            input_vcf=subset_vcf,
+            input_vcf_index=subset_vcf_index,
+            experiment=experiment,
+            ref_fai=ref_fai,
+            bed_regions=bed_regions,
+            bed_labels=bed_labels,
+            svlen_bin_cutoffs=svlen_bin_cutoffs
+    }
+
+    if (length(bed_regions) > 0) {
+        call SV_tasks.AddIntervalOverlapStats as QcMetricsIntervals {
+            input:
+                input_table=QcMetrics.stats,
+                table_label="qc_stats",
+                output_name="qc_stats",
+                bed_regions=bed_regions,
+                bed_labels=bed_labels,
+                ref_fai=ref_fai,
+                breakpoint_padding=breakpoint_padding
+        }
+    }
+
+    File qc_file = select_first([QcMetricsIntervals.output_table, QcMetrics.stats])
+
+    output {
+        File qc_summary = qc_file
+    }
+}
+
+task CollectQcMetrics {
+    input {
+        File input_vcf
+        File input_vcf_index
+
+        String experiment = ""
+
+        File ref_fai
+
+        Array[File] bed_regions = []
+        Array[String] bed_labels = []
+        Int breakpoint_padding = 20
+
+        Array[Int] svlen_bin_cutoffs = [100, 250, 1000, 2500, 10000, 25000]
+        Array[Int] af_bin_cutoffs = [1, 10, 50]
+        Boolean count_singletons_separate = true
+
+        # Runtime parameters
+        RuntimeAttributes runtimeAttributes = {"disk_size": ceil(2 * size(input_vcf, "GB")) + 100, "cpu": 4, "memory": 16}
+    }
+
+    command <<<
+        set -xueo pipefail
+
+        # Add allele count annotations, in case they're missing
+        bcftools +fill-tags -o tagged.vcf.gz "~{input_vcf}"
+        bcftools index -t -f tagged.vcf.gz
+
+        # Main query formatting
+        # Use POS0/END0 for coherence with bed coordinates later
+        MAIN_HEADER="CHROM\tPOS\tEND\tQUAL\tFILTER\tSVTYPE\tSVLEN\tAC\tAC_Het\tAC_Hom\tAN\tExcHet\tHWE\tAF\tMAF\tNS\tSample\tExperiment"
+        MAIN_QUERY="%CHROM\t%POS0\t%END0\t%QUAL\t%FILTER\t%INFO/SVTYPE\t%INFO/SVLEN\t%AC\t%AC_Het\t%AC_Hom\t%AN\t%ExcHet\t%HWE\t%AF\t%MAF\t%NS\n"
+
+        # Create table of relevant stats from variant annotations
+        # Requires input to have INFO fields: END, SVTYPE, SVLEN
+        echo -e "${MAIN_HEADER}" > qc_stats-pre_intervals.tsv
+        bcftools query -i 'INFO/SVTYPE!="."' \
+            -f"${MAIN_QUERY}" \
+            tagged.vcf.gz | awk -v OFS='\t' '{ print $0, "~{experiment}" }' >> qc_stats-pre_intervals.tsv
+
+        # Add extra stats to QC
+        python3 << CODE
+        import pandas as pd
+
+        qc_df = pd.read_csv('qc_stats-pre_intervals.tsv', sep='\t')
+
+        # Add AC_Ref counts
+        qc_df['AC_Ref'] = qc_df['NS'] - qc_df['AC_Het'] - qc_df['AC_Hom'] / 2
+
+        # Bin AF
+        AF_Bin_cutoffs = [~{default="" sep=", " af_bin_cutoffs}]
+        AF_Bin_start = [f'<{AF_Bin_cutoffs[0]}%']
+        AF_Bins_middle = [f'{AF_Bin_cutoffs[i]}-{AF_Bin_cutoffs[i+1]}%' for i in range(len(AF_Bin_cutoffs)-1)]
+        AF_Bin_end = [f'>{AF_Bin_cutoffs[-1]}%']
+        AF_Bins = AF_Bin_start + AF_Bins_middle + AF_Bin_end
+
+        def bin_af(af):
+            for i, pct in enumerate(AF_Bin_cutoffs):
+                if af < pct/100:
+                    return AF_Bins[i]
+            return AF_Bins[-1]
+
+        # Fill missing AF with 0
+        qc_df['AF_Bin'] = qc_df['AF'].replace('.', 0).astype(float).apply(bin_af)
+        if "~{count_singletons_separate}" == "true":
+            qc_df['AF_Bin'] = qc_df.apply(lambda x: 'AC=1' if x['AC'] == 1 else x['AF_Bin'], axis=1)
+
+        # Bin counts by SVLEN
+        def add_suffix(n):
+            if n < 1_000:
+                return f'{n}'
+            elif n < 1_000_000:
+                return f'{n/1000:.1f}k'
+            elif n < 1_000_000_000:
+                return f'{n/1_000_000:.1f}M'
+            else:
+                return f'{n}'
+
+        SVLEN_Bin_cutoffs = [~{default="" sep=", " svlen_bin_cutoffs}]
+        SVLEN_Bin_start = [f'<{add_suffix(SVLEN_Bin_cutoffs[0])}']
+        SVLEN_Bins_middle = [f'{add_suffix(SVLEN_Bin_cutoffs[i])}-{add_suffix(SVLEN_Bin_cutoffs[i+1])}' for i in range(len(SVLEN_Bin_cutoffs)-1)]
+        SVLEN_Bin_end = [f'>{add_suffix(SVLEN_Bin_cutoffs[-1])}']
+        SVLEN_Bins = SVLEN_Bin_start + SVLEN_Bins_middle + SVLEN_Bin_end
+
+        def bin_svlen(num):
+            for i, bin in enumerate(SVLEN_Bin_cutoffs):
+                if num < bin:
+                    return SVLEN_Bins[i]
+            return SVLEN_Bins[-1]
+
+        qc_df['SVLEN_Bin'] = qc_df['SVLEN'].replace('.', 0).apply(bin_svlen)
+
+        qc_df.to_csv('qc_stats-pre_intervals.tsv', sep='\t', index=False)
+
+        CODE
+
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/sv_docker:v1.0"
+        disks: "local-disk " + runtimeAttributes.disk_size + " HDD"
+        memory: runtimeAttributes.memory + " GB"
+        cpu: runtimeAttributes.cpu
+    }
+
+    output {
+        File stats = "qc_stats-pre_intervals.tsv"
+    }
+}

--- a/BenchmarkSVs/tasks.wdl
+++ b/BenchmarkSVs/tasks.wdl
@@ -1,0 +1,137 @@
+version 1.0
+
+struct RuntimeAttributes {
+    Int disk_size
+    Int cpu
+    Int memory
+}
+
+task AddIntervalOverlapStats {
+    input {
+        File input_table
+        String table_label
+
+        String output_name
+
+        Array[File] bed_regions
+        Array[String] bed_labels
+
+        File ref_fai
+
+        Int breakpoint_padding = 20
+
+        # Runtime Parameters
+        RuntimeAttributes runtimeAttributes = {"disk_size": ceil(2 * size(input_table, "GB")) + 100, "cpu": 4, "memory": 16}
+    }
+
+    command <<<
+        set -xeuo pipefail
+
+        # Clean ref_fai into genome file for bedtools
+        cut -f1,2 ~{ref_fai} > ref.genome
+
+        # Collect interval bed overlap stats
+        # Assumes input_table will have first three columns: CHROM, POS0, END0 with no header
+        generate_interval_stats () {
+            INTERVAL_LABEL=$1
+            INTERVAL_FILE=$2
+            INPUT_LABEL=$3
+            VCF_FILE=$4
+
+            echo -e "${INTERVAL_LABEL}-count\t${INTERVAL_LABEL}-overlap" > header.txt
+            # WARNING: annotate does not preserve order of input bed regions!
+            cut -f1-3 $VCF_FILE > vcf.bed
+            bedtools annotate -both -i vcf.bed -files $INTERVAL_FILE | bedtools sort -i - | rev | cut -f1-2 | rev > "${INTERVAL_LABEL}-${INPUT_LABEL}-preheader.bed"
+            cat header.txt "${INTERVAL_LABEL}-${INPUT_LABEL}-preheader.bed" > "${INTERVAL_LABEL}-${INPUT_LABEL}-annotated.bed"
+
+            # Also add in breakpoint overlap stats using POS and END values
+            echo -e "${INTERVAL_LABEL}-LBEND-count\t${INTERVAL_LABEL}-LBEND-overlap" > pos-header.txt
+            echo -e "${INTERVAL_LABEL}-RBEND-count\t${INTERVAL_LABEL}-RBEND-overlap" > end-header.txt
+            awk '{OFS="\t"; print $1, $2, $2}' vcf.bed | bedtools slop -b ~{breakpoint_padding} -i - -g ref.genome > pos.bed
+            awk '{OFS="\t"; print $1, $3, $3}' vcf.bed | bedtools slop -b ~{breakpoint_padding} -i - -g ref.genome > end.bed
+            bedtools annotate -both -i pos.bed -files $INTERVAL_FILE | bedtools sort -i - | rev | cut -f1-2 | rev > "${INTERVAL_LABEL}-${INPUT_LABEL}-pos-preheader.bed"
+            bedtools annotate -both -i end.bed -files $INTERVAL_FILE | bedtools sort -i - | rev | cut -f1-2 | rev > "${INTERVAL_LABEL}-${INPUT_LABEL}-end-preheader.bed"
+            cat pos-header.txt "${INTERVAL_LABEL}-${INPUT_LABEL}-pos-preheader.bed" > "${INTERVAL_LABEL}-${INPUT_LABEL}-pos-annotated.bed"
+            cat end-header.txt "${INTERVAL_LABEL}-${INPUT_LABEL}-end-preheader.bed" > "${INTERVAL_LABEL}-${INPUT_LABEL}-end-annotated.bed"
+
+            # Paste together three overlap stats files
+            paste "${INTERVAL_LABEL}-${INPUT_LABEL}-annotated.bed" "${INTERVAL_LABEL}-${INPUT_LABEL}-pos-annotated.bed" "${INTERVAL_LABEL}-${INPUT_LABEL}-end-annotated.bed" > "${INTERVAL_LABEL}-${INPUT_LABEL}-full-annotated.bed"
+        }
+
+        INTERVAL_FILES=(~{sep=' ' bed_regions})
+        INTERVAL_LABELS=(~{sep=' ' bed_labels})
+
+        # split header from table content
+        # head -1 "~{input_table}" > table.hdr
+        tail -n+2 "~{input_table}" > table_content.tsv
+
+        for i in {0..~{length(bed_regions)-1}}
+        do
+            INTERVAL_LABEL="${INTERVAL_LABELS[$i]}"
+            CURRENT_FILE="${INTERVAL_FILES[$i]}"
+            generate_interval_stats $INTERVAL_LABEL $CURRENT_FILE "~{table_label}" table_content.tsv
+        done
+
+        # Combine across interval beds
+        paste "~{input_table}" *-~{table_label}-full-annotated.bed > "~{output_name}.tsv"
+
+        # Correct POS0/END0 back to original VCF POS/END coordinates
+        python3 << CODE
+        import pandas as pd
+
+        df = pd.read_csv('~{output_name}.tsv', sep='\t')
+        df['POS'] = df['POS'] + 1
+        df['END'] = df['END'] + 1
+        df.to_csv('~{output_name}.tsv', sep='\t', index=False)
+
+        CODE
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/sv_docker:v1.0"
+        disks: "local-disk " + runtimeAttributes.disk_size + " HDD"
+        memory: runtimeAttributes.memory + " GB"
+        cpu: runtimeAttributes.cpu
+    }
+
+    output {
+        File output_table = "~{output_name}.tsv"
+    }
+}
+
+task SubsetEvaluation {
+    input {
+        File input_vcf
+        File input_vcf_index
+
+        File evaluation_bed
+        Float? evaluation_pct
+
+        # Runtime parameters
+        RuntimeAttributes runtimeAttributes = {"disk_size": ceil(2 * size(input_vcf, "GB")) + 100, "cpu": 4, "memory": 16}
+    }
+
+    command <<<
+        set -xueo pipefail
+
+        # Subset input VCF to only sites which intersect evaluation regions over pct overlap threshold
+        bcftools view -h ~{input_vcf} > header.txt
+        bedtools intersect -a ~{input_vcf} -b ~{evaluation_bed} ~{"-f " + evaluation_pct} -u > variants.vcf
+
+        cat header.txt variants.vcf | bcftools view -o output.vcf.gz -
+        bcftools index -t output.vcf.gz
+
+    >>>
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/sv_docker:v1.0"
+        disks: "local-disk " + runtimeAttributes.disk_size + " HDD"
+        memory: runtimeAttributes.memory + " GB"
+        cpu: runtimeAttributes.cpu
+    }
+
+    output {
+        File output_vcf = "output.vcf.gz"
+        File output_vcf_index = "output.vcf.gz.tbi"
+    }
+}

--- a/BenchmarkSVs/tasks.wdl
+++ b/BenchmarkSVs/tasks.wdl
@@ -88,7 +88,7 @@ task AddIntervalOverlapStats {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/sv_docker:v1.0"
+        docker: "us.gcr.io/broad-dsde-methods/sv_docker:v1.1"
         disks: "local-disk " + runtimeAttributes.disk_size + " HDD"
         memory: runtimeAttributes.memory + " GB"
         cpu: runtimeAttributes.cpu
@@ -124,7 +124,7 @@ task SubsetEvaluation {
     >>>
 
     runtime {
-        docker: "us.gcr.io/broad-dsde-methods/sv_docker:v1.0"
+        docker: "us.gcr.io/broad-dsde-methods/sv_docker:v1.1"
         disks: "local-disk " + runtimeAttributes.disk_size + " HDD"
         memory: runtimeAttributes.memory + " GB"
         cpu: runtimeAttributes.cpu

--- a/Utilities/Dockers/README.md
+++ b/Utilities/Dockers/README.md
@@ -105,12 +105,13 @@ includes some minimal Python tools (pandas) for data processing.
 ## sv_docker
 
 * Directory: SVDocker
-* Description: A docker image containing various tools used in workflows for benchmarking SV files. It contains htslib, bcftools, bedtools, truvari, pandas, and pysam.
-* Location: `us.gcr.io/broad-dsde-methods/sv_docker:v1.0`
+* Description: A docker image containing various tools used in workflows for benchmarking SV files. It contains htslib, bcftools, bedtools, truvari, pandas, pysam, mafft, and hiphase.
+* Location: `us.gcr.io/broad-dsde-methods/sv_docker:v1.1`
 * Used By: [BenchmarkSVs](/BenchmarkSVs/BenchmarkSVs.wdl), [CleanSVs](/BenchmarkSVs/CleanSVs.wdl)
 * Usage: Various; e.g. `bcftools [COMMAND]`, `bedtools [COMMAND]`, `truvari [COMMAND]`, and in Python scripts.
 * Version Notes:
   * 1.0: Versions are `htslib` 1.18, `bcftools` 1.18, `bedtools` 2.31.0, `truvari` 4.0.0, `pandas` 2.1.3, `pysam` 0.22.0 
+  * 1.1: Versions are `htslib` 1.21, `bcftools` 1.21, `bedtools` 2.31.0, `truvari` 4.3.1, `pandas` 2.2.3, `pysam` 0.22.1, `mafft` 7.475, `hiphase` 1.4.5
 
 ## vcfdist
 * Directory: Vcfdist
@@ -136,8 +137,9 @@ includes some minimal Python tools (pandas) for data processing.
 
 * Directory: WhatsHap
 * Description: A docker image containing an installation of [WhatsHap](https://whatshap.readthedocs.io/en/latest/).
-* Location: `us.gcr.io/broad-dsde-methods/whatshap:v1`
+* Location: `us.gcr.io/broad-dsde-methods/whatshap:v1.1`
 * Used By: [BenchmarkPhasing](../../BenchmarkPhasing/BenchmarkPhasing.wdl), [PhaseVCF](../../BenchmarkPhasing/PhaseVCF.wdl)
 * Usage: `whatshap [COMMAND]`
 * Version Notes:
   * 1.0: Versions are `whatshap` 1.7
+  * 1.1: Versions are `whatshap` 2.3, `bcftools` 1.21

--- a/Utilities/Dockers/SVDocker/Dockerfile
+++ b/Utilities/Dockers/SVDocker/Dockerfile
@@ -1,17 +1,18 @@
 # This Dockerfile is used to build the monolithic docker image used for most of the tasks in the BenchmarkSVs and CleanSVs workflows.
-# It contains htslib, bcftools, truvari, pandas, and bedtools.
-FROM ubuntu:22.04
+# It contains htslib, bcftools, truvari, pandas, bedtools, mafft, hiphase.
+FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y git python3 python3-pip wget libbz2-dev liblzma-dev libcurl4-openssl-dev
-RUN pip install truvari==4.0.0 pandas==2.1.3 pysam==0.22.0
+# RUN pip install --break-system-packages --upgrade pip
+RUN pip install --break-system-packages pywfa==0.5.1 truvari==4.3.1 pandas==2.2.3 pysam==0.22.1
 
 # Install htslib
-RUN git clone --recurse-submodules --branch 1.18 https://github.com/samtools/htslib.git
+RUN git clone --recurse-submodules --branch 1.21 https://github.com/samtools/htslib.git
 WORKDIR htslib
 RUN make && make install
 
 # Install bcftools
 WORKDIR /
-RUN git clone --branch 1.18 https://github.com/samtools/bcftools.git
+RUN git clone --branch 1.21 https://github.com/samtools/bcftools.git
 WORKDIR bcftools
 RUN make && make install
 ENV BCFTOOLS_PLUGINS="/bcftools/plugins/"
@@ -20,3 +21,18 @@ ENV BCFTOOLS_PLUGINS="/bcftools/plugins/"
 WORKDIR /
 ADD https://github.com/arq5x/bedtools2/releases/download/v2.31.0/bedtools.static .
 RUN mv bedtools.static bedtools && chmod +x bedtools && cp bedtools /bin/
+
+## Add MAFFT (for truvari refine step)
+WORKDIR /
+RUN git clone https://github.com/GSLBiotech/mafft
+WORKDIR mafft/core
+RUN make install
+WORKDIR /
+
+## Add HiPhase (to phase SVs before truvari refine)
+RUN mkdir -p hiphase
+ADD https://github.com/PacificBiosciences/HiPhase/releases/download/v1.4.5/hiphase-v1.4.5-x86_64-unknown-linux-gnu.tar.gz hiphase
+WORKDIR hiphase
+RUN tar -xvzf hiphase-v1.4.5-x86_64-unknown-linux-gnu.tar.gz
+RUN cp hiphase-v1.4.5-x86_64-unknown-linux-gnu/hiphase /bin
+WORKDIR /

--- a/Utilities/Dockers/WhatsHap/Dockerfile
+++ b/Utilities/Dockers/WhatsHap/Dockerfile
@@ -1,7 +1,15 @@
-FROM ubuntu:23.04
-RUN apt-get update && \
-    apt-get install -y git python3 python3-pip python3-dev build-essential libbz2-dev liblzma-dev libcurl4-openssl-dev libncurses-dev tabix && \
-    pip install whatshap==1.7 && \
-    rm -rf /var/lib/apt/lists/*
+FROM ubuntu:24.04
+RUN apt-get update && apt-get install -y git python3 python-is-python3 python3-pip wget libbz2-dev liblzma-dev libcurl4-openssl-dev python3-pandas curl
+
+# Make bcftools
+RUN wget https://github.com/samtools/bcftools/releases/download/1.21/bcftools-1.21.tar.bz2
+RUN tar -xvf bcftools-1.21.tar.bz2
+WORKDIR bcftools-1.21
+RUN ./configure && make && make install
+RUN export PATH=/bcftools-1.21/bcftools:$PATH
+
+# Install whatshap
+RUN pip install whatshap==2.3 --break-system-packages
 
 RUN export PATH=$HOME/.local/bin:$PATH
+WORKDIR /


### PR DESCRIPTION
This PR includes a bunch of refactoring, improvements, and new features for the process of benchmarking SV VCFs. At a high level, this includes:

- Allow for the option to use `truvari refine` and `truvari ga4gh` for collapsing (or "harmonizing") similar events in truth/query down to one event to try to improve benchmarking statistics where calls might get mismatched due to extreme fuzziness in the calling step. This includes an alignment step using `mafft` as outlined in the `truvari` documentation on the process. The docker image is updated to include newer versions of truvari as well as mafft. This option requires the input files to be phased.
- Splits multiallelic sites before running truvari since the tool expects this (previous this would be expected for the users to preprocess in this way, but this adds a quick convenience).
- The QC tasks were split out into a separate workflow to streamline the benchmarking vs qc/counting tasks. Some common tasks were moved to a third file and are imported.
- Dockstore yml has been updated to be able to import both workflows there.
- The benchmarking stats also include a breakdown by HET vs HOM sites (and both together).