### PR TITLE
GLIMPSE2 improvements

### DIFF
--- a/GlimpseImputationPipeline/Glimpse2Imputation.wdl
+++ b/GlimpseImputationPipeline/Glimpse2Imputation.wdl
@@ -84,7 +84,7 @@ workflow Glimpse2Imputation {
                 preemptible = preemptible,
                 docker = docker,
                 cpu = select_first([cpu_phase, safety_check_n_cpu, SelectResourceParameters.request_n_cpus]),
-                mem_gb = select_first([mem_gb_phase, safety_check_memory_gb, ceil(SelectResourceParameters.memory_gb * mem_scaling_factor_phase)])
+                mem_gb = select_first([mem_gb_phase, safety_check_memory_gb, ceil(select_first([SelectResourceParameters.memory_gb, -1]) * mem_scaling_factor_phase)])
         }
     }
 

--- a/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl
+++ b/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl
@@ -31,7 +31,6 @@ workflow Glimpse2ImputationAndCheckQC {
         Float? mem_scaling_factor_phase
         Int? cpu_ligate
         Int? mem_gb_ligate
-        File? monitoring_script
 
         # For documentation, please refer to CheckQC.wdl
         File qc_metrics_thresholds
@@ -63,8 +62,7 @@ workflow Glimpse2ImputationAndCheckQC {
             docker_extract_num_sites_from_reference_chunk = docker_extract_num_sites_from_reference_chunk,
             mem_scaling_factor_phase = mem_scaling_factor_phase,
             cpu_ligate = cpu_ligate,
-            mem_gb_ligate = mem_gb_ligate,
-            monitoring_script = monitoring_script
+            mem_gb_ligate = mem_gb_ligate
     }
 
     call Glimpse2CheckQC.Glimpse2CheckQC {
@@ -85,9 +83,6 @@ workflow Glimpse2ImputationAndCheckQC {
         
         File qc_metrics = Glimpse2Imputation.qc_metrics
         File coverage_metrics = Glimpse2Imputation.coverage_metrics
-
-        Array[File?] glimpse_phase_monitoring = Glimpse2Imputation.glimpse_phase_monitoring
-        File? glimpse_ligate_monitoring = Glimpse2Imputation.glimpse_ligate_monitoring
 
         Boolean qc_passed = Glimpse2CheckQC.qc_passed
         File qc_failures = Glimpse2CheckQC.qc_failures

--- a/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl
+++ b/GlimpseImputationPipeline/Glimpse2ImputationAndCheckQC.wdl
@@ -28,6 +28,7 @@ workflow Glimpse2ImputationAndCheckQC {
         Int? preemptible
         String? docker
         String? docker_extract_num_sites_from_reference_chunk
+        Float? mem_scaling_factor_phase
         Int? cpu_ligate
         Int? mem_gb_ligate
         File? monitoring_script
@@ -60,6 +61,7 @@ workflow Glimpse2ImputationAndCheckQC {
             preemptible = preemptible,
             docker = docker,
             docker_extract_num_sites_from_reference_chunk = docker_extract_num_sites_from_reference_chunk,
+            mem_scaling_factor_phase = mem_scaling_factor_phase,
             cpu_ligate = cpu_ligate,
             mem_gb_ligate = mem_gb_ligate,
             monitoring_script = monitoring_script

--- a/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl
+++ b/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl
@@ -28,6 +28,7 @@ workflow Glimpse2ImputationInBatches {
         Int? preemptible
         String? docker
         String? docker_extract_num_sites_from_reference_chunk
+        Float? mem_scaling_factor_phase
         Int? cpu_ligate
         Int? mem_gb_ligate
         Int? mem_gb_merge
@@ -68,6 +69,7 @@ workflow Glimpse2ImputationInBatches {
                 preemptible = preemptible,
                 docker = docker,
                 docker_extract_num_sites_from_reference_chunk = docker_extract_num_sites_from_reference_chunk,
+                mem_scaling_factor_phase = mem_scaling_factor_phase,
                 cpu_ligate = cpu_ligate,
                 mem_gb_ligate = mem_gb_ligate,
                 monitoring_script = monitoring_script

--- a/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl
+++ b/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl
@@ -38,7 +38,7 @@ workflow Glimpse2ImputationInBatches {
         String? docker_count_samples
         String? docker_merge
 
-        File interval_list_for_merge
+        File? interval_list_for_merge
         Int? merge_scatter_count
     }
 

--- a/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl
+++ b/GlimpseImputationPipeline/Glimpse2ImputationInBatches.wdl
@@ -32,7 +32,6 @@ workflow Glimpse2ImputationInBatches {
         Int? cpu_ligate
         Int? mem_gb_ligate
         Int? mem_gb_merge
-        File? monitoring_script
 
         String? docker_gatk
         String? docker_count_samples
@@ -71,8 +70,7 @@ workflow Glimpse2ImputationInBatches {
                 docker_extract_num_sites_from_reference_chunk = docker_extract_num_sites_from_reference_chunk,
                 mem_scaling_factor_phase = mem_scaling_factor_phase,
                 cpu_ligate = cpu_ligate,
-                mem_gb_ligate = mem_gb_ligate,
-                monitoring_script = monitoring_script
+                mem_gb_ligate = mem_gb_ligate
         }
     }
 

--- a/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl
+++ b/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl
@@ -13,7 +13,7 @@ workflow Glimpse2MergeBatches {
         String docker_count_samples = "us.gcr.io/broad-dsde-methods/bcftools:v1.3"
         String docker_merge = "us.gcr.io/broad-dsde-methods/samtools-suite:v1.1"
 
-        File interval_list
+        File interval_list = "gs://gcp-public-data--broad-references/hg38/v0/wgs_metrics_intervals.interval_list"
         Int scatter_count = 100
 
         Int mem_gb_merge = 16

--- a/GlimpseImputationPipeline/Glimpse2SplitReference.wdl
+++ b/GlimpseImputationPipeline/Glimpse2SplitReference.wdl
@@ -30,7 +30,7 @@ workflow Glimpse2SplitReference {
         Boolean keep_monomorphic_ref_sites = true
         
         Int preemptible = 1
-        String docker = "us.gcr.io/broad-dsde-methods/glimpse:odelaneau_e0b9b56"
+        String docker = "us.gcr.io/broad-dsde-methods/glimpse:odelaneau_bd93ade"
         File? monitoring_script
     }
 

--- a/GlimpseImputationPipeline/README.md
+++ b/GlimpseImputationPipeline/README.md
@@ -64,7 +64,7 @@ This implementation uses Cromwell's [checkpoint feature](https://cromwell.readth
 
 The memory and CPU resource requirements for the computationally intensive phasing task are automatically determined, based on the number of sites in the reference panel chunks and the number of samples, unless these resource requirements are explicitly defined by setting `cpu_phase` and `mem_gb_phase`. The extraction of the number of sites in the reference panel chunks requires functionality not implemented directly into GLIMPSE2 and is provided in the `docker_extract_num_sites_from_reference_chunk` argument. See the [Docker section](#docker-image-for-extracting-number-of-sites-from-reference-panel) of this README for more information. The memory resource requirement can be scaled linearly using the `mem_scaling_factor_phase` argument.
 
-**Note:** The automatic resource requirement determination provides an estimate of the required resources, it is expected that in some cases the amount of required memory is underestimated. It is therefore advised to run this workflow with Cromwell's [retry with more memory](https://cromwell.readthedocs.io/en/stable/cromwell_features/RetryWithMoreMemory/) feature (also available in [Terra](https://support.terra.bio/hc/en-us/articles/4403215299355-Out-of-Memory-Retry))._
+**Note:** _The automatic resource requirement determination provides an estimate of the required resources, it is expected that in some cases the amount of required memory is underestimated. **It is therefore advised to run this workflow with Cromwell's [retry with more memory](https://cromwell.readthedocs.io/en/stable/cromwell_features/RetryWithMoreMemory/) feature (also available in [Terra](https://support.terra.bio/hc/en-us/articles/4403215299355-Out-of-Memory-Retry)).**_
 
 **Note**: _GLIMPSE2 does not support the input of multiple CRAM files with the same basename when streaming (e.g. `gs://a/file.cram`, `gs://b/file.cram`), due to the way that htslib is implemented. This workflow will check for a potential filename collision and will fail with an error message if such a collision occurs._
 
@@ -87,7 +87,7 @@ The memory and CPU resource requirements for the computationally intensive phasi
 - **Int? effective_population_size**: See [GLIMPSE2 documentation](https://odelaneau.github.io/GLIMPSE/docs/documentation/phase/#model-parameters).
 - **String docker**: Docker image to run imputation with. This docker image requires a few features that the original GLIMPSE2 does not include, see the [Docker section](#Docker-Images) of this README for more information.
 - **String docker_extract_num_sites_from_reference_chunk**: Docker image to extract the number of common and rare sites from each reference chunk. See the [Docker section](#docker-image-for-extracting-number-of-sites-from-reference-panel) of this README for more information.
-- **String mem_scaling_factor_phase**: Linear scaling of the automatically determined memory requirement.
+- **String mem_scaling_factor_phase**: Linear scaling of the automatically determined memory requirement. For running single samples with reference panel chunk sizes of 48 cM, a value of 1.5 is recommended.
 - **Int preemtible = 9**: Number of preemptible attempts.
 
 ### Output

--- a/GlimpseImputationPipeline/README.md
+++ b/GlimpseImputationPipeline/README.md
@@ -64,7 +64,9 @@ The input to this workflow can bei either single-sample or multi-sample VCFs wit
 
 This implementation uses Cromwell's [checkpoint feature](https://cromwell.readthedocs.io/en/stable/optimizations/CheckpointFiles/) to drastically reduce cost by being able to run entirely on preemptible machines and preserving the computation progress made leading up to a preemption event. It is therefore recommended to allow for a relatively high number of preemptible attempts (the default value for the `preemptible` input is 9).
 
-**Note:** _The checkpointing feature, as well as a separate binary required to extract the number of sites in a given reference chunk for resource selection, is not available in the official GLIMPSE repo yet. Therefore, the default value for the `docker` input is set to `us.gcr.io/broad-dsde-methods/ckachulis/glimpse_for_wdl_pipeline:checkpointing_and_extract_num_sites`._
+The memory and CPU resource requirements for the computationally intensive phasing task are automatically determined, based on the number of sites in the reference panel chunks and the number of samples, unless these resource requirements are explicitly defined by setting `cpu_phase` and `mem_gb_phase`. The extraction of the number of sites in the reference panel chunks requires functionality not implemented directly into GLIMPSE2 and is provided in the `docker_extract_num_sites_from_reference_chunk` argument. See the [Docker section](#docker-image-for-extracting-number-of-sites-from-reference-panel) of this README for more information. The memory resource requirement can be scaled linearly using the `mem_scaling_factor_phase` argument.
+
+**Note:** The automatic resource requirement determination provides an estimate of the required resources, it is expected that in some cases the amount of required memory is underestimated. It is therefore advised to run this workflow with Cromwell's [retry with more memory](https://cromwell.readthedocs.io/en/stable/cromwell_features/RetryWithMoreMemory/) feature (also available in [Terra](https://support.terra.bio/hc/en-us/articles/4403215299355-Out-of-Memory-Retry))._
 
 **Note**: _GLIMPSE2 does not support the input of multiple CRAM files with the same basename when streaming (e.g. `gs://a/file.cram`, `gs://b/file.cram`), due to the way that htslib is implemented. This workflow will check for a potential filename collision and will fail with an error message if such a collision occurs._
 
@@ -87,6 +89,7 @@ This implementation uses Cromwell's [checkpoint feature](https://cromwell.readth
 - **Int? effective_population_size**: See [GLIMPSE2 documentation](https://odelaneau.github.io/GLIMPSE/docs/documentation/phase/#model-parameters).
 - **String docker**: Docker image to run imputation with. This docker image requires a few features that the original GLIMPSE2 does not include, see the [Docker section](#Docker-Images) of this README for more information.
 - **String docker_extract_num_sites_from_reference_chunk**: Docker image to extract the number of common and rare sites from each reference chunk. See the [Docker section](#docker-image-for-extracting-number-of-sites-from-reference-panel) of this README for more information.
+- **String mem_scaling_factor_phase**: Linear scaling of the automatically determined memory requirement.
 - **Int preemtible = 9**: Number of preemptible attempts.
 - **File? monitoring_script**: Optional path to monitoring script. If ommitted, no monitoring will occur and the `split_reference_monitoring** output will not be available.
 

--- a/GlimpseImputationPipeline/README.md
+++ b/GlimpseImputationPipeline/README.md
@@ -98,6 +98,7 @@ The memory and CPU resource requirements for the computationally intensive phasi
 - **File imputed_vcf**: Single imputed VCF that covers all regions defined in the `contig_regions` input in GlimpseSplitReference. The name of the file is the basename of `input_vcf` with `.imputed.vcf.gz` added.
 - **File imputed_vcf_index**: Index to `imputed_vcf`.
 - **File? qc_metrics**: Output of Hail's [`sample_qc`](https://hail.is/docs/0.2/methods/genetics.html#hail.methods.sample_qc) method as a TSV table if `collect_qc_metrics` is set, otherwise null.
+- **File? coverage_metrics**: A TSV file containing metrics about the input CRAMs as a way for checking that sufficient coverage has been provided. This output is null if VCF input is provided instead of CRAM input.
 - **Array[File?] glimpse_phase_monitoring**: A monitoring log for each parallelized chunk if the `monitoring_script` input is set, otherwise null.
 - **File? glimpse_ligate_monitoring**: A monitoring log for the ligate task if the `monitoring_script` input is set, otherwise null.
 
@@ -108,6 +109,8 @@ This workflow merges multiple batches of imputed multi-sample VCFs into one and 
 ### Input
 - **Array[File] imputed_vcf**: GLIMPSE2 output imputed VCFs.
 - **Array[File] imputed_vcf_indices**: Indices to `imputed_vcf`.
+- **Int? scatter_count**: Merging large batches of samples (approx. more than 100) requires too much resources to be done in one job. This parameter defines the number of chunks that the genome (as defined by `interval_list`) should be divided into. The default value of 100 is appropriate for merging multiple batches of 1,000 samples each.
+- **File? interval_list**: This file should contain all chromosomes that imputation has been performed on. The default value contains the hg38 contigs chr1-chr22, chrX, chrY, and chrM from start until end. Adding unused contigs only affects the efficiency for the merging process.
 - **Array[File?]? qc_metrics**: Optional array of qc_metrics of the individual batches to be merged into one `merged_qc_metrics` TSV file. Can otherwise be _null_ or can only contain _null_ values.
 - **String output_basename**: Basename for merged output VCF.
 

--- a/GlimpseImputationPipeline/README.md
+++ b/GlimpseImputationPipeline/README.md
@@ -47,14 +47,12 @@ contig_name_in_reference_panel = "chr1"
 - **Int? min_window_cm**: Optional minimum window size in [Centimorgan](https://en.wikipedia.org/wiki/Centimorgan). See note on chunk sizes above.
 - **Boolean uniform_number_variants = false**: When set to true, each chunk will have approximately the same number of sites while. Each chunk will cover a different (Centimorgan) genetic linkage region with the smallest chunk still being larger than `min_window_cm`.
 - **Int preemtible = 1**: Number of preemptible attempts.
-- **File? monitoring_script**: Optional path to monitoring script. If ommitted, no monitoring will occur and the `split_reference_monitoring** output will not be available.
 
 ### Output
 - **Array[File] chunks**: One `chunks_contigindex_{CONTIGINDEX}.txt` file per region as defined in the `contig_regions` input that each include the definitions of the chunks in that region.
 - **Array[File] split_reference_chunks**: All binary representations of the reference panel for each chunk in each contig region. Each file is named `reference_panel_contigindex_${CONTIGINDEX}_chunkindex_${CHUNKINDEX}` with `CONTIGINDEX` and `CHUNKINDEX` being 4-digit zero-based indices with leading zeros in order to simplify the correct ordering of intervals.
 - **Array[String] num_sites**: The number of sites in each chunk.
 - **Array[String] num_sites_uniform**: The number of sites in each chunk when using `uniform_number_variants`, otherwise empty.
-- **File? monitoring**: A monitoring log if the `monitoring_script` input is set, otherwise null.
 
 ## Glimpse2Imputation
 
@@ -91,7 +89,6 @@ The memory and CPU resource requirements for the computationally intensive phasi
 - **String docker_extract_num_sites_from_reference_chunk**: Docker image to extract the number of common and rare sites from each reference chunk. See the [Docker section](#docker-image-for-extracting-number-of-sites-from-reference-panel) of this README for more information.
 - **String mem_scaling_factor_phase**: Linear scaling of the automatically determined memory requirement.
 - **Int preemtible = 9**: Number of preemptible attempts.
-- **File? monitoring_script**: Optional path to monitoring script. If ommitted, no monitoring will occur and the `split_reference_monitoring** output will not be available.
 
 ### Output
 
@@ -99,8 +96,6 @@ The memory and CPU resource requirements for the computationally intensive phasi
 - **File imputed_vcf_index**: Index to `imputed_vcf`.
 - **File? qc_metrics**: Output of Hail's [`sample_qc`](https://hail.is/docs/0.2/methods/genetics.html#hail.methods.sample_qc) method as a TSV table if `collect_qc_metrics` is set, otherwise null.
 - **File? coverage_metrics**: A TSV file containing metrics about the input CRAMs as a way for checking that sufficient coverage has been provided. This output is null if VCF input is provided instead of CRAM input.
-- **Array[File?] glimpse_phase_monitoring**: A monitoring log for each parallelized chunk if the `monitoring_script` input is set, otherwise null.
-- **File? glimpse_ligate_monitoring**: A monitoring log for the ligate task if the `monitoring_script` input is set, otherwise null.
 
 ## Glimpse2MergeBatches
 

--- a/test/Glimpse2Imputation/test_outputs.json
+++ b/test/Glimpse2Imputation/test_outputs.json
@@ -3,7 +3,5 @@
     "Glimpse2Imputation.qc_metrics":"gs://palantir-workflows-test-data/Glimpse2Imputation/test.qc_metrics.20241004.tsv",
     "Glimpse2Imputation.imputed_vcf_index":null,
     "Glimpse2Imputation.imputed_vcf_md5sum":null,
-    "Glimpse2Imputation.glimpse_ligate_monitoring":null,
-    "Glimpse2Imputation.glimpse_phase_monitoring":null,
     "Glimpse2Imputation.imputed_vcf":null
 }


### PR DESCRIPTION
- Added `mem_scaling_factor_phase` for adjusting memory requirements when running in single sample mode
- Updated GLIMPSE2 docker to most recent version from official repo
- Removed monitoring log output, since Terra now has this feature built in
- Added default value for `interval_list` in `Glimpse2MergeBatches`
- Updated documentation in README
- Added automatic tagging in for docker generation script
- Had to rename the `die` function in the shell script to `end_program` because Github Copilot would refuse to do anything in that script