### PR TITLE
Fix and improve panel count calculation in gcnv filtering

### DIFF
--- a/gCNV/cnv_germline_case_filter_workflow.wdl
+++ b/gCNV/cnv_germline_case_filter_workflow.wdl
@@ -363,7 +363,7 @@ task ExtractPoNFreq {
         df_expanded_with_panel['overlapping_panel_exon_end']=np.minimum(df_expanded_with_panel.event_exon_end_sample, df_expanded_with_panel.event_exon_end_panel)
 
         df_expanded['event_exon_length']=df_expanded.event_exon_end - df_expanded.event_exon_start
-        df_expanded_with_panel['overlapping_panel_exon_length']=(df_expanded_with_panel.overlapping_panel_exon_end - df_expanded_with_panel.overlapping_panel_exon_start).fillna(0)
+        df_expanded_with_panel['overlapping_panel_exon_length']=np.maximum(df_expanded_with_panel.overlapping_panel_exon_end - df_expanded_with_panel.overlapping_panel_exon_start,0).fillna(0)
 
         df_panel_counts = df_expanded_with_panel.groupby(['ID_sample','sample_name_panel']).agg(
             {'overlapping_panel_exon_length':'sum'}

--- a/gCNV/cnv_germline_case_filter_workflow.wdl
+++ b/gCNV/cnv_germline_case_filter_workflow.wdl
@@ -312,14 +312,27 @@ task ExtractPoNFreq {
         import numpy as np
 
         intervals = pd.read_csv("~{intervals}", sep="\t", comment="@", names = ["contig","start","end","dummy1","dummy2"])
+        intervals['contig_idx'] = intervals.groupby('contig').cumcount()
+        intervals = intervals.set_index(intervals.contig + "_" + intervals.contig_idx.astype(str))
 
         def add_exon_idxs(df, exons):
-            contigs = set(df.contig)
-            for contig in contigs:
-                df.loc[df.contig==contig,"start_exon_idx"]=np.searchsorted(exons.loc[exons.contig==contig].start,
-                                                                           df.loc[df.contig==contig].start,"left")
-                df.loc[df.contig==contig,"end_exon_idx"]=np.searchsorted(exons.loc[exons.contig==contig].start,
-                                                                           df.loc[df.contig==contig].end,"right")
+                contigs = set(df.contig)
+                for contig in contigs:
+                    df.loc[df.contig==contig,"start_exon_idx"]=np.searchsorted(exons.loc[exons.contig==contig].end,
+                                                                               df.loc[df.contig==contig].start,"left")
+                    df.loc[df.contig==contig,"end_exon_idx"]=np.searchsorted(exons.loc[exons.contig==contig].start,
+                                                                               df.loc[df.contig==contig].end,"right")
+        def get_exon_expanded_events(df, exons):
+            add_exon_idxs(df, exons)
+            df = df.loc[df.start_exon_idx != df.end_exon_idx].reset_index()
+            df_expanded = df.loc[df.index.repeat(df.end_exon_idx-df.start_exon_idx)]
+            df_expanded['exon_idx'] = df_expanded.groupby(df_expanded.index).cumcount() + df_expanded.start_exon_idx
+            df_expanded = df_expanded.set_index(df_expanded.contig + "_" + df_expanded.exon_idx.astype(int).astype(str))
+            df_expanded = df_expanded.join(exons[['start','end']], rsuffix='_exon')
+            df_expanded['event_exon_start']=np.maximum(df_expanded.start, df_expanded.start_exon)
+            df_expanded['event_exon_end']=np.minimum(df_expanded.end, df_expanded.end_exon)
+            df_expanded = df_expanded.set_index(df_expanded.index + "_" + df_expanded.svtype)
+            return df_expanded
 
         def standardize_gt_vcf(df):
             df['end'] = df['INFO'].str.replace('END=','').astype(int) #split('=').apply(lambda x: x[1])
@@ -327,65 +340,45 @@ task ExtractPoNFreq {
             for num,f in enumerate(df.loc[0,'FORMAT'].split(':')):
                 df[f] = df['SAMPLE'].str.split(':').apply(lambda x: x[num])
             return df
-        
+
         def read_vcf_to_df(vcf):
             df = pd.read_csv(vcf, sep='\t',comment='#',compression='gzip',
                                  names=['contig','start','ID','REF','ALT','QUAL','FILTER','INFO','FORMAT','SAMPLE'])
             df = standardize_gt_vcf(df)
-            df['sample_path']=vcf
+            df['sample_name']=vcf.split("/")[-1].split(".")[0]
             for c in ['NP','CN','QA','QS']:
                 df[c]=df[c].astype(int)
             return df
             
-        df = read_vcf_to_df("~{vcf}")
-        add_exon_idxs(df, intervals)
-        df = df.sort_values(["contig","start_exon_idx","end_exon_idx"])
+        df = read_vcf_to_expanded_df("~{vcf}", intervals)
+        df_expanded = get_exon_expanded_events(df, intervals)
 
         vcfs = ["~{sep='","' panel_vcfs}"]
-        df_panel = pd.concat([read_vcf_to_df(vcf) for vcf in vcfs])
-        add_exon_idxs(df_panel, intervals)
-        df_panel = df_panel.sort_values(["contig","start_exon_idx","end_exon_idx"])
+        df_panel = pd.concat([read_vcf_to_expanded_df(vcf, intervals) for vcf in vcfs])
+        df_panel_expanded = get_exon_expanded_events(df_panel, intervals)
 
-        def annotate_with_panel_count(panel_df, df, svtype, contig):
-            panel_df_mask = ((panel_df.svtype==svtype) &
-                             (panel_df.contig == contig))
-            df_mask = ((df.svtype==svtype) &
-                             (df.contig == contig)
-                          )
-            panel_df_slice = panel_df.loc[panel_df_mask]
-            df_slice = df.loc[df_mask]
+        df_expanded = df_expanded.join(df_panel_expanded, how="left", lsuffix="_sample", rsuffix="_panel")
 
-            df.loc[df_mask,"start_panel_idx"]=np.searchsorted(panel_df_slice.end_exon_idx,
-                                                                 df_slice.start_exon_idx, "left")
-            df.loc[df_mask,"end_panel_idx"]=np.searchsorted(panel_df_slice.start_exon_idx,
-                                                                 df_slice.end_exon_idx, "right")
+        df_expanded['overlapping_panel_exon_start']=np.maximum(df_expanded.event_exon_start_sample, df_expanded.event_exon_start_panel)
+        df_expanded['overlapping_panel_exon_end']=np.minimum(df_expanded.event_exon_end_sample, df_expanded.event_exon_end_panel)
 
-            df.loc[df_mask & (df.start_panel_idx ==
-                                         df.end_panel_idx), "PANEL_COUNT"] = 0
-            panel_counts=[]
-            for i, r in df.loc[df_mask & (df.start_panel_idx !=
-                                         df.end_panel_idx)].iterrows():
-                overlapping_panel_events = panel_df_slice.iloc[int(r.start_panel_idx):int(r.end_panel_idx)]
-                overlapping_exon_lengths = (np.minimum(r.end_exon_idx,overlapping_panel_events.end_exon_idx) -
-                                           np.maximum(r.start_exon_idx,overlapping_panel_events.start_exon_idx))
-                overlapping_panel_fracs = overlapping_exon_lengths/(r.end_exon_idx - r.start_exon_idx)
-                overlapping_panel_events = overlapping_panel_events.loc[overlapping_panel_fracs>=~{overlap_thresh}]
-                panel_count =  len(set(overlapping_panel_events.sample_path))
-                panel_counts.append(panel_count)
+        df_expanded['event_exon_length_sample']=df_expanded.event_exon_end_sample - df_expanded.event_exon_start_sample
+        df_expanded['overlapping_panel_exon_length']=(df_expanded.overlapping_panel_exon_end - df_expanded.overlapping_panel_exon_start).fillna(0)
 
-            df.loc[df_mask & (df.start_panel_idx !=
-                                         df.end_panel_idx), "PANEL_COUNT"] = panel_counts
+        df_panel_counts = df_expanded.groupby(['ID_sample','sample_name_panel']).agg(
+            {'event_exon_length_sample':'sum',
+            'overlapping_panel_exon_length':'sum'}
+        )
 
-        n_panel_samples = len(set(df_panel.sample_path))
-        contigs = set(df.contig)
-        svtypes = set(df.svtype)
-        for contig in contigs:
-            for svtype in svtypes:
-                annotate_with_panel_count(df_panel, df, svtype, contig)
+        df_panel_counts['PANEL_COUNT'] = np.where(df_panel_counts.overlapping_panel_exon_length/df_panel_counts.event_exon_length_sample>~{overlap_thresh}, 1, 0)
+        df_panel_counts = df_panel_counts.groupby('ID_sample').agg({'PANEL_COUNT':'sum'})
 
-        df.loc[:,"PANEL_FREQ"]=(df.PANEL_COUNT/n_panel_samples)
+        df = df.set_index('ID').join(df_panel_counts).fillna({'PANEL_COUNT':0}).astype({'PANEL_COUNT':int})
 
-        df_annotations = df[["contig","start","PANEL_FREQ","PANEL_COUNT"]].copy()
+        n_panel_samples = len(set(df_panel.sample_name))
+        df['PANEL_FREQ'] = df['PANEL_COUNT']/n_panel_samples
+
+        df_annotations = df[['contig','start','PANEL_FREQ','PANEL_COUNT']].copy()
         df_annotations = df_annotations.rename({"contig":"CHROM","start":"POS"}, axis=1)
         df_annotations = df_annotations.astype({"PANEL_COUNT":int})
         df_annotations.to_csv("~{basename_out}.annotations.tsv", index = False, sep="\t", float_format="%g")

--- a/gCNV/cnv_germline_case_filter_workflow.wdl
+++ b/gCNV/cnv_germline_case_filter_workflow.wdl
@@ -350,11 +350,11 @@ task ExtractPoNFreq {
                 df[c]=df[c].astype(int)
             return df
             
-        df = read_vcf_to_df("~{vcf}", intervals)
+        df = read_vcf_to_df("~{vcf}")
         df_expanded = get_exon_expanded_events(df, intervals)
 
         vcfs = ["~{sep='","' panel_vcfs}"]
-        df_panel = pd.concat([read_vcf_to_df(vcf, intervals) for vcf in vcfs])
+        df_panel = pd.concat([read_vcf_to_df(vcf) for vcf in vcfs])
         df_panel_expanded = get_exon_expanded_events(df_panel, intervals)
 
         df_expanded = df_expanded.join(df_panel_expanded, how="left", lsuffix="_sample", rsuffix="_panel")

--- a/gCNV/cnv_germline_case_filter_workflow.wdl
+++ b/gCNV/cnv_germline_case_filter_workflow.wdl
@@ -350,11 +350,11 @@ task ExtractPoNFreq {
                 df[c]=df[c].astype(int)
             return df
             
-        df = read_vcf_to_expanded_df("~{vcf}", intervals)
+        df = read_vcf_to_df("~{vcf}", intervals)
         df_expanded = get_exon_expanded_events(df, intervals)
 
         vcfs = ["~{sep='","' panel_vcfs}"]
-        df_panel = pd.concat([read_vcf_to_expanded_df(vcf, intervals) for vcf in vcfs])
+        df_panel = pd.concat([read_vcf_to_df(vcf, intervals) for vcf in vcfs])
         df_panel_expanded = get_exon_expanded_events(df_panel, intervals)
 
         df_expanded = df_expanded.join(df_panel_expanded, how="left", lsuffix="_sample", rsuffix="_panel")

--- a/gCNV/cnv_germline_case_filter_workflow.wdl
+++ b/gCNV/cnv_germline_case_filter_workflow.wdl
@@ -310,6 +310,7 @@ task ExtractPoNFreq {
         python << "EOF"
         import pandas as pd
         import numpy as np
+        import gzip
 
         intervals = pd.read_csv("~{intervals}", sep="\t", comment="@", names = ["contig","start","end","dummy1","dummy2"])
         intervals['contig_idx'] = intervals.groupby('contig').cumcount()

--- a/gCNV/cnv_germline_case_filter_workflow.wdl
+++ b/gCNV/cnv_germline_case_filter_workflow.wdl
@@ -367,7 +367,7 @@ task ExtractPoNFreq {
 
         df_panel_counts = df_expanded_with_panel.groupby(['ID_sample','sample_name_panel']).agg(
             {'overlapping_panel_exon_length':'sum'}
-            ).reset_index('sample_name_panel').join(df_expanded.renamegroupby('ID').agg({'event_exon_length':'sum'})
+            ).reset_index('sample_name_panel').join(df_expanded.groupby('ID').agg({'event_exon_length':'sum'})
         )
 
         df_panel_counts['PANEL_COUNT'] = np.where(df_panel_counts.overlapping_panel_exon_length/df_panel_counts.event_exon_length>0.5, 1, 0)

--- a/gCNV/cnv_germline_case_filter_workflow.wdl
+++ b/gCNV/cnv_germline_case_filter_workflow.wdl
@@ -299,7 +299,7 @@ task ExtractPoNFreq {
         Array[File] panel_vcfs
         File intervals
         Float overlap_thresh = 0.5
-        Int mem_gb = 4
+        Int mem_gb = 16
         Int disk_size_gb = 100
     }
 

--- a/gCNV/cnv_germline_case_filter_workflow.wdl
+++ b/gCNV/cnv_germline_case_filter_workflow.wdl
@@ -370,7 +370,7 @@ task ExtractPoNFreq {
             ).reset_index('sample_name_panel').join(df_expanded.groupby('ID').agg({'event_exon_length':'sum'})
         )
 
-        df_panel_counts['PANEL_COUNT'] = np.where(df_panel_counts.overlapping_panel_exon_length/df_panel_counts.event_exon_length>0.5, 1, 0)
+        df_panel_counts['PANEL_COUNT'] = np.where(df_panel_counts.overlapping_panel_exon_length/df_panel_counts.event_exon_length>~{overlap_thresh}, 1, 0)
         df_panel_counts = df_panel_counts.groupby(df_panel_counts.index).agg({'PANEL_COUNT':'sum'})
 
         df = df.set_index('ID').join(df_panel_counts).fillna({'PANEL_COUNT':0}).astype({'PANEL_COUNT':int})

--- a/test/choose_watt_tests/choose_watt_tests.py
+++ b/test/choose_watt_tests/choose_watt_tests.py
@@ -10,16 +10,24 @@ parser.add_argument("--watt-config", help="WATT config yaml")
 parser.add_argument("--womtool-jar")
 
 #copied from watt
-def resolve_relative_path(rel_path: str) -> str:
+def resolve_path(path: str) -> str:
     """
-    Given test path, check if it should be interpreted as a relative path inside a repo or absolute path on system.
-    Return value is an absolute path on the host system pointing to the file at the given path.
+    Given test path, return an absolute path corresponding to the intended path.
+    If the given path is a relative path (does not begin with / on unix), it is taken to be relative to the current working directory.
+    If the given path is an absolute path (begins with / on unix), then it is taken to either be relative to a git repo if the current
+    working directory is inside a git repo, or absolute on the host system if the current working directory is not inside a git repo or
+    the corresponding file in the git repo does not exist.
     This should allow users running tests on local machines to resolve the correct paths, even if the repo has a
     root given by a non-root dir on the local system.
     """
+    # If the path is not absolute, we assume it is relative to current working directory
+    if not os.path.isabs(path):
+        return os.path.abspath(path)
+
+    # If the path is absolute, we need to check if it is inside a git repo
     in_repo = False
     in_root = False
-    working_dir = os.path.curdir
+    working_dir = os.getcwd()
     while not in_repo and not in_root:
         if os.path.exists(os.path.join(working_dir, os.path.join('.git'))):
             in_repo = True
@@ -28,9 +36,13 @@ def resolve_relative_path(rel_path: str) -> str:
             in_root = working_dir == new_working_dir
             working_dir = new_working_dir
     if in_repo:
-        return os.path.join(working_dir, rel_path.removeprefix('/'))
+        in_repo_path = os.path.join(working_dir, path.removeprefix('/'))
+        if os.path.exists(in_repo_path):
+            return in_repo_path
+        else:
+            return path
     else:
-        return rel_path
+        return path
 
 def get_wdl_dependencies(womtool_run: subprocess.CompletedProcess):
     return [line.decode() for line in womtool_run.stdout.splitlines() if line.endswith(b'.wdl')]
@@ -48,16 +60,16 @@ if __name__ == '__main__':
     tests_to_run = set()
     
     if args.changed_workflows or args.changed_jsons: 
-        changed_wdls = {resolve_relative_path(path) for path in args.changed_workflows} if args.changed_workflows else set()
-        changed_jsons = {resolve_relative_path(path) for path in args.changed_jsons} if args.changed_jsons else set()
+        changed_wdls = {resolve_path(path) for path in args.changed_workflows} if args.changed_workflows else set()
+        changed_jsons = {resolve_path(path) for path in args.changed_jsons} if args.changed_jsons else set()
 
         for wf, wf_tests_info in config.items():
-            wdl_path = resolve_relative_path(wf_tests_info['path'])
+            wdl_path = resolve_path(wf_tests_info['path'])
             if wdl_path in changed_wdls:
                 tests_to_run.add(wf)
             else:
                 for test, test_info in wf_tests_info['tests'].items():
-                    if resolve_relative_path(test_info['test_inputs']) in changed_jsons or resolve_relative_path(test_info['expected_outputs']) in changed_jsons:
+                    if resolve_path(test_info['test_inputs']) in changed_jsons or resolve_path(test_info['expected_outputs']) in changed_jsons:
                         tests_to_run.add(wf)
             if wf not in tests_to_run:
                 womtool_run = subprocess.run(['java', "-jar", args.womtool_jar, "validate", "-l", wdl_path], capture_output=True)


### PR DESCRIPTION
Fixes a bug in the panel count calculation, and additionally improves it.

Previously, events in a case sample were matched to events in the panel by the following algorithm:

1. label each event in the case sample and panel which the list of exons it overlaps.
2. For an event in the case sample, a sample in the panel is considered to contain the same event in the fraction of exons overlapped by the event which are also overlapped by events of the same type in the panel sample is greater than a specified "overlap threshold"

The bug was that when labeling events with exons, an event was considered to overlap an exon only if it overlapped the start of the exon.  This meant that if, for example, and event started part way through an exon, it would not be labeled with that exon.

This PR firstly fixes that bug, so that events are associated with all exons they overlap in any way.  
Additionally, the matching algorithm is changed to the following:
1. For each event in the case sample, find the total exon length it covers.  Note that if an event only partially covers an exon, it is now only credited with the amount of the exon it covers, not the full length of the exon.
2. When comparing an event in the case sample to a panel sample, calculate the total exonic length of the event which is covered by events of the same type in the panel sample.  If the ratio of this value to the total exonic length of the event is greater than the "overlap threshold", than the event is considered observed in that panel sample.
