### PR TITLE
Fix Python-Data-Slim Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PALANTIR-WORKFLOWS
 
-[![Test Status](https://github.com/broadinstitute/palantir-workflows/actions/workflows/run_tests.yaml/badge.svg?branch=main)](https://github.com/broadinstitute/palantir-workflows/actions/workflows/run_tests.yaml/badge.svg?branch=main)
+[![Test Status](https://github.com/broadinstitute/palantir-workflows/actions/workflows/run_tests.yaml/badge.svg?branch=main)](https://github.com/broadinstitute/palantir-workflows/actions/workflows/run_tests.yaml/badge.svg?branch=main) [![Dockerfiles Status](https://github.com/broadinstitute/palantir-workflows/actions/workflows/test_dockerfiles.yaml/badge.svg?branch=main)](https://github.com/broadinstitute/palantir-workflows/actions/workflows/test_dockerfiles.yaml/badge.svg?branch=main)
 
 Utility workflows used by the DSP's Palantir team.  This repository should be used to manage frequently used utility workflows for the team, and facilitate their use on [Terra](https://app.terra.bio/) through [Dockstore](https://dockstore.org/).
 

--- a/Utilities/Dockers/Python-Data-Slim/Dockerfile
+++ b/Utilities/Dockers/Python-Data-Slim/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.12.5
 RUN pip install pandas==2.2.2 \
 numpy==2.1.0 \
 scipy==1.14.0 \
-firecloud==0.16.37 \
+setuptools==79.0.1 \
 fsspec==2024.6.1 \
 gcsfs==2024.6.1
+RUN pip install --no-build-isolation firecloud==0.16.37


### PR DESCRIPTION
[`package_index` was recently removed from setuptools](https://github.com/pypa/setuptools/pull/4963#issuecomment-2851940964), but is used in firecloud `setup.py`, so installing firecloud in the docker fails.  



fix is to install older version of setuptools, and then force pip to use the installed version of setup tools with the [`--no-build-isolation`](https://github.com/pypa/setuptools/discussions/4354) option.