### PR TITLE
f-string for older versions of python

### DIFF
--- a/GlimpseImputationPipeline/DeliverGlimpseCohort/DeliverGlimpseCohort.py
+++ b/GlimpseImputationPipeline/DeliverGlimpseCohort/DeliverGlimpseCohort.py
@@ -80,7 +80,7 @@ def record_delivery(source_namespace, source_workspace, cohort_name, target_name
     
     with StringIO() as table_io:
         table_io.write('entity:delivery_id\tsource_cohort\ttarget_namespace\ttarget_workspace\tdelivery_date\t' + '\t'.join(delivered_files.keys()) + '\n')
-        table_io.write(f'{delivery_id}\t{cohort_name}\t{target_namespace}\t{target_workspace}\t{now.strftime('%Y_%m_%d_%H:%M:%SZ')}\t' + '\t'.join(delivered_files.values()) + '\n')
+        table_io.write(f'{delivery_id}\t{cohort_name}\t{target_namespace}\t{target_workspace}\t{now.strftime("%Y_%m_%d_%H:%M:%SZ")}\t' + '\t'.join(delivered_files.values()) + '\n')
         response = fapi.upload_entities_tsv(source_namespace, source_workspace, table_io, model='flexible')
         if not response.ok:
             raise RuntimeError(f'ERROR recording delivery f{delivery_id}: {response.text}')


### PR DESCRIPTION
prior to python3.12, quote reuse in f-strings raises a syntax error.  https://docs.python.org/3.12/whatsnew/3.12.html#pep-701-syntactic-formalization-of-f-strings

this PR is so script will run correctly for versions older than 3.12 (but newer than 3.6)