### PR TITLE
Fix: re-index input VCF before rtg vcfeval to handle TDR path mismatches

### DIFF
--- a/BenchmarkVCFs/BenchmarkVCFs.wdl
+++ b/BenchmarkVCFs/BenchmarkVCFs.wdl
@@ -250,16 +250,17 @@ task VCFEval {
 
         # rtg vcfeval requires the index to be co-located with the VCF
         # handle cases where index is provided in a different location
-        colocate_tbi() {
+        colocate_index() {
             local vcf="$1"
             local index="$2"
+            local index_ext="${index##*.}"
 
-             if [ ! -f "${vcf}.tbi" ]; then
-                cp "${index}" "${vcf}.tbi"
+            if [ ! -f "${vcf}.${index_ext}" ]; then
+                cp "${index}" "${vcf}.${index_ext}"
             fi
         }
-        colocate_tbi ~{base_vcf} ~{base_vcf_index}
-        colocate_tbi ~{query_vcf} ~{query_vcf_index}
+        colocate_index ~{base_vcf} ~{base_vcf_index}
+        colocate_index ~{query_vcf} ~{query_vcf_index}
 
         # Make bed file for full reference
         awk -v OFS="\t" '{print $1, 0, $2}' ~{reference.index} > genome_file.bed

--- a/BenchmarkVCFs/BenchmarkVCFs.wdl
+++ b/BenchmarkVCFs/BenchmarkVCFs.wdl
@@ -251,7 +251,7 @@ task VCFEval {
         # rtg vcfeval requires the index to be co-located with the VCF
         # handle cases where index is provided in a different location
         if [ ! -f "~{query_vcf}.tbi" ]; then
-            cp ~{vcf_index} "~{query_vcf}.tbi"
+            cp "~{query_vcf_index}" "~{query_vcf}.tbi"
         fi
 
         # Make bed file for full reference

--- a/BenchmarkVCFs/BenchmarkVCFs.wdl
+++ b/BenchmarkVCFs/BenchmarkVCFs.wdl
@@ -248,9 +248,11 @@ task VCFEval {
     command <<<
         set -xeuo pipefail
 
-        # rtg vcfeval requires the index to be co-located with the VCF; re-index to guarantee this.
-        bcftools index -t ~{query_vcf}
-        bcftools index -t ~{base_vcf}
+        # rtg vcfeval requires the index to be co-located with the VCF
+        # handle cases where index is provided in a different location
+        if [ ! -f "~{query_vcf}.tbi" ]; then
+            cp ~{vcf_index} "~{query_vcf}.tbi"
+        fi
 
         # Make bed file for full reference
         awk -v OFS="\t" '{print $1, 0, $2}' ~{reference.index} > genome_file.bed

--- a/BenchmarkVCFs/BenchmarkVCFs.wdl
+++ b/BenchmarkVCFs/BenchmarkVCFs.wdl
@@ -248,6 +248,10 @@ task VCFEval {
     command <<<
         set -xeuo pipefail
 
+        # rtg vcfeval requires the index to be co-located with the VCF; re-index to guarantee this.
+        bcftools index -t ~{query_vcf}
+        bcftools index -t ~{base_vcf}
+
         # Make bed file for full reference
         awk -v OFS="\t" '{print $1, 0, $2}' ~{reference.index} > genome_file.bed
         echo "AllRegions" > labels.txt

--- a/BenchmarkVCFs/BenchmarkVCFs.wdl
+++ b/BenchmarkVCFs/BenchmarkVCFs.wdl
@@ -250,9 +250,16 @@ task VCFEval {
 
         # rtg vcfeval requires the index to be co-located with the VCF
         # handle cases where index is provided in a different location
-        if [ ! -f "~{query_vcf}.tbi" ]; then
-            cp "~{query_vcf_index}" "~{query_vcf}.tbi"
-        fi
+        colocate_tbi() {
+            local vcf="$1"
+            local index="$2"
+
+             if [ ! -f "${vcf}.tbi" ]; then
+                cp "${index}" "${vcf}.tbi"
+            fi
+        }
+        colocate_tbi "~{base_vcf}" "~{base_vcf_index}"
+        colocate_tbi "~{query_vcf}" "~{query_vcf_index}"
 
         # Make bed file for full reference
         awk -v OFS="\t" '{print $1, 0, $2}' ~{reference.index} > genome_file.bed

--- a/BenchmarkVCFs/BenchmarkVCFs.wdl
+++ b/BenchmarkVCFs/BenchmarkVCFs.wdl
@@ -258,8 +258,8 @@ task VCFEval {
                 cp "${index}" "${vcf}.tbi"
             fi
         }
-        colocate_tbi "~{base_vcf}" "~{base_vcf_index}"
-        colocate_tbi "~{query_vcf}" "~{query_vcf_index}"
+        colocate_tbi ~{base_vcf} ~{base_vcf_index}
+        colocate_tbi ~{query_vcf} ~{query_vcf_index}
 
         # Make bed file for full reference
         awk -v OFS="\t" '{print $1, 0, $2}' ~{reference.index} > genome_file.bed


### PR DESCRIPTION
## Problem                                                                                                                                             
rtg vcfeval requires the VCF index file to be in the same directory as the input VCF. In Terra/cromwell, companion files are only auto-co-localized when the VCF and their index share the exact same GCS path prefix. When the index file is re-uploaded to a versioned path (e.g., `RP_3449/2/PDO-36062/` instead of `RP_3449/PDO-36062/`), cromwell localizes it to a different directory than the VCF, and rtg vcfeval fails with Index not found.

This was observed for a recent submission: the VCF resolved to `.../RP_3449/PDO-36062/` while the index file resolved to `.../RP_3449/2/PDO-36062/` — are-upload had placed the TBI one level deeper. 

Here is the link to the failed submission: https://app.terra.bio/#workspaces/broadtagteam/BCL_cWGS_PositiveControls_Benchmarking/submission_history/6d6a21dc-dbe9-4fa5-b97d-69b3815d1cb2       
                          
## Fix
Add `bcftools index -t` before the `rtg vcfeval` to unconditionally regenerate the index in the same local directory as the localized VCF. This removes any dependency on TDR path layout or upload history.                                   
