### PR TITLE
Fix glimpse docker script

### DIFF
--- a/GlimpseImputationPipeline/glimpse_docker/build_base_and_extension_docker.sh
+++ b/GlimpseImputationPipeline/glimpse_docker/build_base_and_extension_docker.sh
@@ -124,7 +124,7 @@ if docker images | grep "temp_glimpse_base" > /dev/null; then
     exit 1
 fi
 
-git clone $repo --branch $branch --single-branch ${script_dir}/glimpse_base
+git clone $repo --branch $branch --recursive --single-branch ${script_dir}/glimpse_base
 
 if [[ "$tag" != *":"* ]]; then
     prefix="https://github.com/"


### PR DESCRIPTION
GLIMPSE recently [added SIMDe as a submodule to support SIMD across more hardware/distros](https://github.com/odelaneau/GLIMPSE/pull/286).  Build script for Glimpse docker now needs to download submodule as well.