### PR TITLE
HPV Normalization bug fixes

### DIFF
--- a/HPVDeepSeek/HPVDeepSeekNormalization.wdl
+++ b/HPVDeepSeek/HPVDeepSeekNormalization.wdl
@@ -37,13 +37,12 @@ task NormalizeHPV {
 
             for idx, row in df.iterrows():
                 total_depth = 0
-                num_positions = 0
-                for pileupcolumn in infile_simplex.pileup(row.chromosome, row.start, row.end, stepper = "all", truncate = False, max_depth = 1000000, ignore_overlaps = True):
+                for pileupcolumn in infile_simplex.pileup(row.chromosome, row.start, row.end, stepper = "all", truncate = True, max_depth = 1000000, ignore_overlaps = True):
                     for pileupread in pileupcolumn.pileups:
                         if pileupread.alignment.get_tag("cD") >= 5:
                             total_depth += 1
-                    num_positions += 1
 
+                num_positions = row.end - row.start
                 mean_depth = 0.0
                 if num_positions > 0:
                     mean_depth = total_depth / num_positions

--- a/HPVDeepSeek/HPVDeepSeekNormalization.wdl
+++ b/HPVDeepSeek/HPVDeepSeekNormalization.wdl
@@ -51,13 +51,15 @@ task NormalizeHPV {
         hg38_median_depth = df.loc[~df["chromosome"].str.startswith("HPV") & ~df["chromosome"].str.startswith("chrX") & ~df["chromosome"].str.startswith("chrY"), "mean_depth"].median()
 
         df = df[df["chromosome"].isin(df_detected_hpv_genotypes["HPV_Genotype"].tolist())]
-        df["HPV_Mean_Depth_Over_hg38_Median_Depth"] = df["mean_depth"] / hg38_median_depth
+        df = df.rename(columns = {"mean_depth": "HPV_Mean_Depth"})
+        df['hg38_median_depth'] = hg38_median_depth
+        df["HPV_Mean_Depth_Over_hg38_Median_Depth"] = df["HPV_Mean_Depth"] / hg38_median_depth
         df["ng_cfDNA"] = ~{ng_cfdna}
         df["mL_Plasma"] = ~{ul_plasma} / 1000.0
         df["HPV_Quantity"] = df["HPV_Mean_Depth_Over_hg38_Median_Depth"] * ((df["ng_cfDNA"] / 0.0033) / df["mL_Plasma"])
 
         df = df.rename(columns = {"chromosome": "HPV_Genotype"})
-        df = df[["HPV_Genotype", "HPV_Mean_Depth_Over_hg38_Median_Depth", "ng_cfDNA", "mL_Plasma", "HPV_Quantity"]]
+        df = df[["HPV_Genotype", "HPV_Mean_Depth", "hg38_median_depth", "HPV_Mean_Depth_Over_hg38_Median_Depth", "ng_cfDNA", "mL_Plasma", "HPV_Quantity"]]
         df.to_csv("~{sample_id}.normalized_hpv.tsv", sep = '\t', index = False)
 
         CODE


### PR DESCRIPTION
@kockan for when you get back.

Fixes a couple of bugs in the HPV Normalization

pysam pileup will only return pileups for positions covered by at least 1 read, so current implementation only calculates mean coverage over bases with 1+ read coverage.  This inflates hpv mean coverage in very low titer situations, where most of the hpv genome is uncovered.  PR fixes this.

Also changes "Truncate=False" to "Truncate=True" to restrict calculation to only specified sites, as opposed to any site which is covered by any read which also covers specified sites.  likely a minimal effect, bust feels cleaner.

Also adds HPV_Mean_Depth and hg38_median_depth to output tsv.

